### PR TITLE
Preventing XML Signature Wrapping attacks in SAML.

### DIFF
--- a/components/org.wso2.carbon.identity.application.authenticator.samlsso/src/main/java/org/wso2/carbon/identity/application/authenticator/samlsso/manager/DefaultSAML2SSOManager.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.samlsso/src/main/java/org/wso2/carbon/identity/application/authenticator/samlsso/manager/DefaultSAML2SSOManager.java
@@ -60,6 +60,7 @@ import org.opensaml.saml2.core.impl.NameIDPolicyBuilder;
 import org.opensaml.saml2.core.impl.RequestedAuthnContextBuilder;
 import org.opensaml.saml2.core.impl.SessionIndexBuilder;
 import org.opensaml.saml2.encryption.Decrypter;
+import org.opensaml.security.SAMLSignatureProfileValidator;
 import org.opensaml.xml.ConfigurationException;
 import org.opensaml.xml.XMLObject;
 import org.opensaml.xml.encryption.EncryptedKey;
@@ -894,6 +895,9 @@ public class DefaultSAML2SSOManager implements SAML2SSOManager {
                         "not found in SAML Response element.");
             } else {
                 try {
+                    SAMLSignatureProfileValidator signatureProfileValidator = new SAMLSignatureProfileValidator();
+                    signatureProfileValidator.validate(response.getSignature());
+
                     X509Credential credential =
                             new X509CredentialImpl(tenantDomain, identityProvider.getCertificate());
                     SignatureValidator validator = new SignatureValidator(credential);
@@ -916,6 +920,9 @@ public class DefaultSAML2SSOManager implements SAML2SSOManager {
                         "not found in SAML Assertion element.");
             } else {
                 try {
+                    SAMLSignatureProfileValidator signatureProfileValidator = new SAMLSignatureProfileValidator();
+                    signatureProfileValidator.validate(assertion.getSignature());
+
                     X509Credential credential =
                             new X509CredentialImpl(tenantDomain, identityProvider.getCertificate());
                     SignatureValidator validator = new SignatureValidator(credential);


### PR DESCRIPTION
First the signature should be validated with org.opensaml.security.SAMLSignatureProfileValidator. This will ensure that the signature follows the standard for XML signatures, and will avoid certain types of DoS attacks associated with the signature.
Only after that, the cryptographic validation of the signature should be performed.
