### PR TITLE
IDENTITY-4819 : SSO flow is not working as expected in chrome

### DIFF
--- a/components/org.wso2.carbon.identity.application.authenticator.samlsso/src/main/java/org/wso2/carbon/identity/application/authenticator/samlsso/SAMLSSOAuthenticator.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.samlsso/src/main/java/org/wso2/carbon/identity/application/authenticator/samlsso/SAMLSSOAuthenticator.java
@@ -415,7 +415,7 @@ public class SAMLSSOAuthenticator extends AbstractApplicationAuthenticator imple
 
         try {
             String postPage = SAMLSSOAuthenticatorServiceComponent.getPostPage();
-
+            response.setContentType("text/html; charset=UTF-8");
             if (postPage != null) {
                 String pageWithURL = postPage.replace("$url", Encode.forHtmlAttribute(url));
                 String finalPage = pageWithURL.replace("<!--$params-->", postPageInputs);


### PR DESCRIPTION
X-Content-Type-Options header is now enforced. Chrome and IE supports this header and expects 'Content-Type' header always.
