### PR TITLE
Improved Assertion validity period validation

### DIFF
--- a/components/org.wso2.carbon.identity.application.authenticator.samlsso/pom.xml
+++ b/components/org.wso2.carbon.identity.application.authenticator.samlsso/pom.xml
@@ -117,6 +117,7 @@
 
                             org.w3c.dom.*,
 
+                            org.wso2.carbon.identity.core.util; version="${carbon.identity.framework.imp.pkg.version.range}",
                             org.wso2.carbon.identity.application.authentication.framework.*; version="${carbon.identity.framework.imp.pkg.version.range}",
                             org.wso2.carbon.identity.application.common.model; version="${carbon.identity.framework.imp.pkg.version.range}",
                             org.wso2.carbon.identity.application.common.util; version="${carbon.identity.framework.imp.pkg.version.range}",

--- a/features/org.wso2.carbon.identity.application.authenticator.samlsso.server.feature/pom.xml
+++ b/features/org.wso2.carbon.identity.application.authenticator.samlsso.server.feature/pom.xml
@@ -77,6 +77,7 @@
                             </bundles>
                             <importFeatures>
                                 <importFeatureDef>org.wso2.carbon.core:compatible:${carbon.kernel.version}</importFeatureDef>
+                                <importFeatureDef>org.wso2.carbon.identity.core.server:compatible:${carbon.identity.framework.version}</importFeatureDef>
                                 <importFeatureDef>org.wso2.carbon.identity.application.mgt.server:compatible:${carbon.identity.framework.version}</importFeatureDef>
                                 <importFeatureDef>org.wso2.carbon.identity.application.authentication.framework.server:compatible:${carbon.identity.framework.version}</importFeatureDef>
                                 <importFeatureDef>org.wso2.carbon.security.mgt.server:compatible:${carbon.identity.framework.version}</importFeatureDef>

--- a/pom.xml
+++ b/pom.xml
@@ -283,7 +283,7 @@
         <carbon.user.api.imp.pkg.version.range>[1.0.1, 2.0.0)</carbon.user.api.imp.pkg.version.range>
 
         <!--Carbon Identity Framework Version-->
-        <carbon.identity.framework.version>5.2.0</carbon.identity.framework.version>
+        <carbon.identity.framework.version>5.2.1-SNAPSHOT</carbon.identity.framework.version>
         <carbon.identity.framework.imp.pkg.version.range>[5.0.0, 6.0.0)</carbon.identity.framework.imp.pkg.version.range>
 
         <!-- Carbon Commons -->


### PR DESCRIPTION
This PR improves the assertion validity period verification by taking the server synchronization tolerance value into measure.

This tolerance value is configured under /repository/conf/identity/identity.xml file in seconds and by default it is 300 seconds.
&lt;ClockSkew&gt;300&lt;/ClockSkew&gt;
