### PR TITLE
Improve debug logs to find the cause of SAML Assertion is not found in the Response.

### DIFF
--- a/components/org.wso2.carbon.identity.application.authenticator.samlsso/src/main/java/org/wso2/carbon/identity/application/authenticator/samlsso/manager/DefaultSAML2SSOManager.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.samlsso/src/main/java/org/wso2/carbon/identity/application/authenticator/samlsso/manager/DefaultSAML2SSOManager.java
@@ -532,16 +532,26 @@ public class DefaultSAML2SSOManager implements SAML2SSOManager {
         }
 
         if (assertion == null) {
-            if (samlResponse.getStatus() != null &&
-                    samlResponse.getStatus().getStatusCode() != null &&
-                    samlResponse.getStatus().getStatusCode().getValue().equals(
-                            SSOConstants.StatusCodes.IDENTITY_PROVIDER_ERROR) &&
-                    samlResponse.getStatus().getStatusCode().getStatusCode() != null &&
-                    samlResponse.getStatus().getStatusCode().getStatusCode().getValue().equals(
-                            SSOConstants.StatusCodes.NO_PASSIVE)) {
-                return;
+            if (samlResponse.getStatus() != null && samlResponse.getStatus().getStatusCode() != null) {
+                if (samlResponse.getStatus().getStatusCode().getValue().equals(
+                        SSOConstants.StatusCodes.IDENTITY_PROVIDER_ERROR)) {
+                    if (samlResponse.getStatus().getStatusCode().getStatusCode() != null &&
+                            samlResponse.getStatus().getStatusCode().getStatusCode().getValue().equals(
+                                    SSOConstants.StatusCodes.NO_PASSIVE)) {
+                        return;
+                    } else if (log.isDebugEnabled()) {
+                        log.debug("SAML Response status code object is either null or it's value is " +
+                                "not equal to: " + SSOConstants.StatusCodes.NO_PASSIVE + ".");
+                    }
+                } else if (log.isDebugEnabled()) {
+                    log.debug("SAML Response status code value is: " +
+                            samlResponse.getStatus().getStatusCode().getValue() + ".");
+                }
+            } else if (log.isDebugEnabled()) {
+                log.debug("SAML Response status or the status code is null.");
             }
-            throw new SAMLSSOException("SAML Assertion is not found in the Response");
+
+            throw new SAMLSSOException("SAML Assertion is not found in the Response.");
         }
 
         // Validate the assertion issuer. This is an optional validation which is not mandate by the spec.

--- a/components/org.wso2.carbon.identity.application.authenticator.samlsso/src/main/java/org/wso2/carbon/identity/application/authenticator/samlsso/manager/DefaultSAML2SSOManager.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.samlsso/src/main/java/org/wso2/carbon/identity/application/authenticator/samlsso/manager/DefaultSAML2SSOManager.java
@@ -535,17 +535,25 @@ public class DefaultSAML2SSOManager implements SAML2SSOManager {
             if (samlResponse.getStatus() != null && samlResponse.getStatus().getStatusCode() != null) {
                 if (samlResponse.getStatus().getStatusCode().getValue().equals(
                         SSOConstants.StatusCodes.IDENTITY_PROVIDER_ERROR)) {
-                    if (samlResponse.getStatus().getStatusCode().getStatusCode() != null &&
-                            samlResponse.getStatus().getStatusCode().getStatusCode().getValue().equals(
-                                    SSOConstants.StatusCodes.NO_PASSIVE)) {
-                        return;
+                    if (samlResponse.getStatus().getStatusCode().getStatusCode() != null) {
+                        if (samlResponse.getStatus().getStatusCode().getStatusCode().getValue().equals(
+                                SSOConstants.StatusCodes.NO_PASSIVE)) {
+                            return;
+                        } else if (log.isDebugEnabled()) {
+                            log.debug("SAML Response status code object value is: " +
+                                    samlResponse.getStatus().getStatusCode().getStatusCode().getValue()
+                                    + ".");
+                            throw new SAMLSSOException("SAML Response status code object value is not" +
+                                    "equal to: " + SSOConstants.StatusCodes.NO_PASSIVE + ".");
+                        }
                     } else if (log.isDebugEnabled()) {
-                        log.debug("SAML Response status code object is either null or it's value is " +
-                                "not equal to: " + SSOConstants.StatusCodes.NO_PASSIVE + ".");
+                        log.debug("SAML Response status code object is null.");
                     }
                 } else if (log.isDebugEnabled()) {
                     log.debug("SAML Response status code value is: " +
                             samlResponse.getStatus().getStatusCode().getValue() + ".");
+                    throw new SAMLSSOException("SAML Response status code value is not equal to: " +
+                            SSOConstants.StatusCodes.IDENTITY_PROVIDER_ERROR + ".");
                 }
             } else if (log.isDebugEnabled()) {
                 log.debug("SAML Response status or the status code is null.");


### PR DESCRIPTION
- Added debug logs to find the cause of SAML Assertion is not found in the Response.
- Throw error specific message instead of a generic message "SAML Assertion is not found in the Response" at some places.

Fixes: https://github.com/wso2/product-is/issues/6088