### PR TITLE
NameIdPolicy ignored if not specified in SAML IDP metadata configuration

### DIFF
--- a/components/org.wso2.carbon.identity.application.authenticator.samlsso/src/main/java/org/wso2/carbon/identity/application/authenticator/samlsso/manager/DefaultSAML2SSOManager.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.samlsso/src/main/java/org/wso2/carbon/identity/application/authenticator/samlsso/manager/DefaultSAML2SSOManager.java
@@ -100,6 +100,7 @@ import org.wso2.carbon.identity.application.common.model.ClaimMapping;
 import org.wso2.carbon.identity.application.common.model.IdentityProvider;
 import org.wso2.carbon.identity.application.common.util.IdentityApplicationConstants;
 import org.wso2.carbon.identity.application.common.util.IdentityApplicationManagementUtil;
+import org.wso2.carbon.identity.base.IdentityConstants;
 import org.wso2.carbon.identity.core.ServiceURLBuilder;
 import org.wso2.carbon.identity.core.URLBuilderException;
 import org.wso2.carbon.identity.core.util.IdentityUtil;
@@ -787,7 +788,18 @@ public class DefaultSAML2SSOManager implements SAML2SSOManager {
 
         String includeNameIDPolicyProp = properties
                 .get(IdentityApplicationConstants.Authenticator.SAML2SSO.INCLUDE_NAME_ID_POLICY);
-        if (Boolean.parseBoolean(includeNameIDPolicyProp)) {
+
+        boolean isNameIDPolicyPropIncluded;
+        if (Boolean.parseBoolean(IdentityUtil.getProperty(
+                IdentityConstants.ServerConfig.ADD_NAME_ID_POLICY_IF_UNSPECIFIED))) {
+            // Adding empty string check for backward compatibility.
+            isNameIDPolicyPropIncluded = StringUtils.isEmpty(includeNameIDPolicyProp) ||
+                    Boolean.parseBoolean(includeNameIDPolicyProp);
+        } else {
+            isNameIDPolicyPropIncluded = Boolean.parseBoolean(includeNameIDPolicyProp);
+        }
+
+        if (isNameIDPolicyPropIncluded) {
             NameIDPolicyBuilder nameIdPolicyBuilder = new NameIDPolicyBuilder();
             NameIDPolicy nameIdPolicy = nameIdPolicyBuilder.buildObject();
 

--- a/components/org.wso2.carbon.identity.application.authenticator.samlsso/src/main/java/org/wso2/carbon/identity/application/authenticator/samlsso/manager/DefaultSAML2SSOManager.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.samlsso/src/main/java/org/wso2/carbon/identity/application/authenticator/samlsso/manager/DefaultSAML2SSOManager.java
@@ -787,7 +787,7 @@ public class DefaultSAML2SSOManager implements SAML2SSOManager {
 
         String includeNameIDPolicyProp = properties
                 .get(IdentityApplicationConstants.Authenticator.SAML2SSO.INCLUDE_NAME_ID_POLICY);
-        if (StringUtils.isEmpty(includeNameIDPolicyProp) || Boolean.parseBoolean(includeNameIDPolicyProp)) {
+        if (Boolean.parseBoolean(includeNameIDPolicyProp)) {
             NameIDPolicyBuilder nameIdPolicyBuilder = new NameIDPolicyBuilder();
             NameIDPolicy nameIdPolicy = nameIdPolicyBuilder.buildObject();
 

--- a/components/org.wso2.carbon.identity.application.authenticator.samlsso/src/test/java/org/wso2/carbon/identity/application/authenticator/samlsso/manager/DefaultSAML2SSOManagerTest.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.samlsso/src/test/java/org/wso2/carbon/identity/application/authenticator/samlsso/manager/DefaultSAML2SSOManagerTest.java
@@ -592,8 +592,7 @@ public class DefaultSAML2SSOManagerTest {
             assertTrue(TestConstants.ACS_INDEX.equals(authnRequest.getAttributeConsumingServiceIndex().toString()),
                     "Failed to set ACS index");
         }
-        if (StringUtils.isEmpty(requestData.getIncludeNameIDPolicyProp()) || Boolean.parseBoolean(requestData
-                .getIncludeNameIDPolicyProp())) {
+        if (Boolean.parseBoolean(requestData.getIncludeNameIDPolicyProp())) {
             assertNotNull(authnRequest.getNameIDPolicy(), "Failed to set NameID policy");
         } else {
             assertNull(authnRequest.getNameIDPolicy(), "Invalid NameID policy");

--- a/pom.xml
+++ b/pom.xml
@@ -355,7 +355,7 @@
         <carbon.user.api.imp.pkg.version.range>[1.0.1, 2.0.0)</carbon.user.api.imp.pkg.version.range>
 
         <!--Carbon Identity Framework Version-->
-        <carbon.identity.framework.version>5.18.21</carbon.identity.framework.version>
+        <carbon.identity.framework.version>5.18.101</carbon.identity.framework.version>
         <carbon.identity.framework.imp.pkg.version.range>[5.15.0, 6.0.0)</carbon.identity.framework.imp.pkg.version.range>
 
         <!--SAML Common Util Version-->


### PR DESCRIPTION
**Fixes: https://github.com/wso2/product-is/issues/9271**

**Related PRs: https://github.com/wso2/carbon-identity-framework/pull/3099**