### PR TITLE
Enable HTTP-Artifact binding for SAML2 federation

### DIFF
--- a/components/org.wso2.carbon.identity.application.authenticator.samlsso/src/main/java/org/wso2/carbon/identity/application/authenticator/samlsso/manager/DefaultSAML2SSOManager.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.samlsso/src/main/java/org/wso2/carbon/identity/application/authenticator/samlsso/manager/DefaultSAML2SSOManager.java
@@ -759,7 +759,13 @@ public class DefaultSAML2SSOManager implements SAML2SSOManager {
         String includeProtocolBindingProp = properties
                 .get(IdentityApplicationConstants.Authenticator.SAML2SSO.INCLUDE_PROTOCOL_BINDING);
         if (StringUtils.isEmpty(includeProtocolBindingProp) || Boolean.parseBoolean(includeProtocolBindingProp)) {
-            authRequest.setProtocolBinding(SAMLConstants.SAML2_POST_BINDING_URI);
+            String isArtifactBindingEnabledProp = properties
+                    .get(IdentityApplicationConstants.Authenticator.SAML2SSO.IS_ARTIFACT_BINDING_ENABLED);
+            if ( StringUtils.isEmpty(isArtifactBindingEnabledProp) || Boolean.parseBoolean(isArtifactBindingEnabledProp) ) {
+                authRequest.setProtocolBinding(SAMLConstants.SAML2_ARTIFACT_BINDING_URI);
+            } else {
+                authRequest.setProtocolBinding(SAMLConstants.SAML2_POST_BINDING_URI);
+            }
         }
 
         AuthenticatorConfig authenticatorConfig =


### PR DESCRIPTION
Current code does not allow to set ProtocolBinding attribute in AuthnRequest message with "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Artifact" value even though there is an "Enable Artifact Binding" property in SAML2 federation authorization configuration.