### PR TITLE
Change JIT provisioned Managed profile name

### DIFF
--- a/components/org.wso2.carbon.identity.application.authenticator.samlsso/src/main/java/org/wso2/carbon/identity/application/authenticator/samlsso/util/SSOConstants.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.samlsso/src/main/java/org/wso2/carbon/identity/application/authenticator/samlsso/util/SSOConstants.java
@@ -23,7 +23,7 @@ import java.util.regex.Pattern;
 public class SSOConstants {
 
     public static final String AUTHENTICATOR_NAME = "SAMLSSOAuthenticator";
-    public static final String AUTHENTICATOR_FRIENDLY_NAME = "samlsso";
+    public static final String AUTHENTICATOR_FRIENDLY_NAME = "SAML SSO";
 
     public static final String HTTP_POST_PARAM_SAML2_AUTH_REQ = "SAMLRequest";
     public static final String HTTP_POST_PARAM_SAML2_RESP = "SAMLResponse";


### PR DESCRIPTION
Related https://github.com/wso2-enterprise/asgardeo-product/issues/5963

Change the `AUTHENTICATOR_FRIENDLY_NAME` constant of SAML SSO Authenticator as the `SAML SSO`.