### PR TITLE
Multiple authentication context classes for SAML IDP

### DIFF
--- a/components/org.wso2.carbon.identity.application.authenticator.samlsso/src/main/java/org/wso2/carbon/identity/application/authenticator/samlsso/manager/DefaultSAML2SSOManager.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.samlsso/src/main/java/org/wso2/carbon/identity/application/authenticator/samlsso/manager/DefaultSAML2SSOManager.java
@@ -901,7 +901,7 @@ public class DefaultSAML2SSOManager implements SAML2SSOManager {
                     .get(IdentityApplicationConstants.Authenticator.SAML2SSO.AUTHENTICATION_CONTEXT_CLASS);
 
             if (StringUtils.isNotEmpty(authnContextClass)) {
-                String[] authnContextClassList = authnContextClass.split(",");
+                String[] authnContextClassList = authnContextClass.split(DEFAULT_MULTI_ATTRIBUTE_SEPARATOR);
                 for (String authnContextClassListElement : authnContextClassList) {
                     AuthnContextClassRef authnContextClassRef = authnContextClassRefBuilder
                             .buildObject(SAMLConstants.SAML20_NS,
@@ -909,11 +909,11 @@ public class DefaultSAML2SSOManager implements SAML2SSOManager {
                                     SAMLConstants.SAML20_PREFIX);
                     String samlAuthnContextURN = IdentityApplicationManagementUtil
                             .getSAMLAuthnContextClasses().get(authnContextClassListElement);
-                    if (!StringUtils.isBlank(samlAuthnContextURN)) {
-                        //There was one matched URN for given authnContextClass.
+                    if (StringUtils.isNotBlank(samlAuthnContextURN)) {
+                        // There was one matched URN for given authnContextClass.
                         authnContextClassRef.setAuthnContextClassRef(samlAuthnContextURN);
                     } else {
-                        //There are no any matched URN for given authnContextClass, so added authnContextClassListElement name to the
+                        // There are no any matched URN for given authnContextClass, so added authnContextClassListElement name to the
                         // AuthnContextClassRef.
                         authnContextClassRef.setAuthnContextClassRef(authnContextClassListElement);
                     }

--- a/components/org.wso2.carbon.identity.application.authenticator.samlsso/src/main/java/org/wso2/carbon/identity/application/authenticator/samlsso/manager/DefaultSAML2SSOManager.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.samlsso/src/main/java/org/wso2/carbon/identity/application/authenticator/samlsso/manager/DefaultSAML2SSOManager.java
@@ -897,11 +897,11 @@ public class DefaultSAML2SSOManager implements SAML2SSOManager {
             /* AuthnContextClass */
             AuthnContextClassRefBuilder authnContextClassRefBuilder = new AuthnContextClassRefBuilder();
 
-            String authnContextClass = properties
+            String authnContextClasses = properties
                     .get(IdentityApplicationConstants.Authenticator.SAML2SSO.AUTHENTICATION_CONTEXT_CLASS);
 
-            if (StringUtils.isNotBlank(authnContextClass)) {
-                String[] authnContextClassList = authnContextClass.split(DEFAULT_MULTI_ATTRIBUTE_SEPARATOR);
+            if (StringUtils.isNotBlank(authnContextClasses)) {
+                String[] authnContextClassList = authnContextClasses.split(DEFAULT_MULTI_ATTRIBUTE_SEPARATOR);
                 for (String authnContextClassListElement : authnContextClassList) {
                     AuthnContextClassRef authnContextClassRef = authnContextClassRefBuilder
                             .buildObject(SAMLConstants.SAML20_NS,
@@ -912,7 +912,7 @@ public class DefaultSAML2SSOManager implements SAML2SSOManager {
                             .CUSTOM_AUTHENTICATION_CONTEXT_CLASS_OPTION)) {
                         samlAuthnContextURN = properties.get(IdentityApplicationConstants.Authenticator
                                 .SAML2SSO.ATTRIBUTE_CUSTOM_AUTHENTICATION_CONTEXT_CLASS);
-                    } else{
+                    } else {
                         samlAuthnContextURN = IdentityApplicationManagementUtil
                                 .getSAMLAuthnContextClasses().get(authnContextClassListElement);
                     }

--- a/components/org.wso2.carbon.identity.application.authenticator.samlsso/src/main/java/org/wso2/carbon/identity/application/authenticator/samlsso/manager/DefaultSAML2SSOManager.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.samlsso/src/main/java/org/wso2/carbon/identity/application/authenticator/samlsso/manager/DefaultSAML2SSOManager.java
@@ -900,7 +900,7 @@ public class DefaultSAML2SSOManager implements SAML2SSOManager {
             String authnContextClass = properties
                     .get(IdentityApplicationConstants.Authenticator.SAML2SSO.AUTHENTICATION_CONTEXT_CLASS);
 
-            if (StringUtils.isNotEmpty(authnContextClass)) {
+            if (StringUtils.isNotBlank(authnContextClass)) {
                 String[] authnContextClassList = authnContextClass.split(DEFAULT_MULTI_ATTRIBUTE_SEPARATOR);
                 for (String authnContextClassListElement : authnContextClassList) {
                     AuthnContextClassRef authnContextClassRef = authnContextClassRefBuilder

--- a/components/org.wso2.carbon.identity.application.authenticator.samlsso/src/main/java/org/wso2/carbon/identity/application/authenticator/samlsso/manager/DefaultSAML2SSOManager.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.samlsso/src/main/java/org/wso2/carbon/identity/application/authenticator/samlsso/manager/DefaultSAML2SSOManager.java
@@ -907,8 +907,16 @@ public class DefaultSAML2SSOManager implements SAML2SSOManager {
                             .buildObject(SAMLConstants.SAML20_NS,
                                     AuthnContextClassRef.DEFAULT_ELEMENT_LOCAL_NAME,
                                     SAMLConstants.SAML20_PREFIX);
-                    String samlAuthnContextURN = IdentityApplicationManagementUtil
-                            .getSAMLAuthnContextClasses().get(authnContextClassListElement);
+                    String samlAuthnContextURN;
+                    if (authnContextClassListElement.equals(IdentityApplicationConstants.Authenticator.SAML2SSO
+                            .CUSTOM_AUTHENTICATION_CONTEXT_CLASS_OPTION)) {
+                        samlAuthnContextURN = properties.get(IdentityApplicationConstants.Authenticator
+                                .SAML2SSO.ATTRIBUTE_CUSTOM_AUTHENTICATION_CONTEXT_CLASS);
+                    } else{
+                        samlAuthnContextURN = IdentityApplicationManagementUtil
+                                .getSAMLAuthnContextClasses().get(authnContextClassListElement);
+                    }
+
                     if (StringUtils.isNotBlank(samlAuthnContextURN)) {
                         // There was one matched URN for given authnContextClass.
                         authnContextClassRef.setAuthnContextClassRef(samlAuthnContextURN);

--- a/components/org.wso2.carbon.identity.application.authenticator.samlsso/src/main/java/org/wso2/carbon/identity/application/authenticator/samlsso/manager/DefaultSAML2SSOManager.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.samlsso/src/main/java/org/wso2/carbon/identity/application/authenticator/samlsso/manager/DefaultSAML2SSOManager.java
@@ -896,28 +896,37 @@ public class DefaultSAML2SSOManager implements SAML2SSOManager {
             requestedAuthnContext = requestedAuthnContextBuilder.buildObject();
             /* AuthnContextClass */
             AuthnContextClassRefBuilder authnContextClassRefBuilder = new AuthnContextClassRefBuilder();
-            AuthnContextClassRef authnContextClassRef = authnContextClassRefBuilder
-                    .buildObject(SAMLConstants.SAML20_NS,
-                            AuthnContextClassRef.DEFAULT_ELEMENT_LOCAL_NAME,
-                            SAMLConstants.SAML20_PREFIX);
 
             String authnContextClass = properties
                     .get(IdentityApplicationConstants.Authenticator.SAML2SSO.AUTHENTICATION_CONTEXT_CLASS);
 
             if (StringUtils.isNotEmpty(authnContextClass)) {
-                String samlAuthnContextURN = IdentityApplicationManagementUtil
-                        .getSAMLAuthnContextClasses().get(authnContextClass);
-                if (!StringUtils.isBlank(samlAuthnContextURN)) {
-                    //There was one matched URN for give authnContextClass.
-                    authnContextClassRef.setAuthnContextClassRef(samlAuthnContextURN);
-                } else {
-                    //There are no any matched URN for given authnContextClass, so added authnContextClass name to the
-                    // AuthnContextClassRef.
-                    authnContextClassRef.setAuthnContextClassRef(authnContextClass);
+                String[] authnContextClassList = authnContextClass.split(",");
+                for (String authnContextClassListElement : authnContextClassList) {
+                    AuthnContextClassRef authnContextClassRef = authnContextClassRefBuilder
+                            .buildObject(SAMLConstants.SAML20_NS,
+                                    AuthnContextClassRef.DEFAULT_ELEMENT_LOCAL_NAME,
+                                    SAMLConstants.SAML20_PREFIX);
+                    String samlAuthnContextURN = IdentityApplicationManagementUtil
+                            .getSAMLAuthnContextClasses().get(authnContextClassListElement);
+                    if (!StringUtils.isBlank(samlAuthnContextURN)) {
+                        //There was one matched URN for given authnContextClass.
+                        authnContextClassRef.setAuthnContextClassRef(samlAuthnContextURN);
+                    } else {
+                        //There are no any matched URN for given authnContextClass, so added authnContextClassListElement name to the
+                        // AuthnContextClassRef.
+                        authnContextClassRef.setAuthnContextClassRef(authnContextClassListElement);
+                    }
+                    requestedAuthnContext.getAuthnContextClassRefs().add(authnContextClassRef);
                 }
 
             } else {
+                AuthnContextClassRef authnContextClassRef = authnContextClassRefBuilder
+                        .buildObject(SAMLConstants.SAML20_NS,
+                                AuthnContextClassRef.DEFAULT_ELEMENT_LOCAL_NAME,
+                                SAMLConstants.SAML20_PREFIX);
                 authnContextClassRef.setAuthnContextClassRef(AuthnContext.PPT_AUTHN_CTX);
+                requestedAuthnContext.getAuthnContextClassRefs().add(authnContextClassRef);
             }
 
             /* Authentication Context Comparison Level */
@@ -941,7 +950,6 @@ public class DefaultSAML2SSOManager implements SAML2SSOManager {
             } else {
                 requestedAuthnContext.setComparison(AuthnContextComparisonTypeEnumeration.EXACT);
             }
-            requestedAuthnContext.getAuthnContextClassRefs().add(authnContextClassRef);
         }
         return requestedAuthnContext;
     }

--- a/components/org.wso2.carbon.identity.application.authenticator.samlsso/src/test/java/org/wso2/carbon/identity/application/authenticator/samlsso/TestConstants.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.samlsso/src/test/java/org/wso2/carbon/identity/application/authenticator/samlsso/TestConstants.java
@@ -396,6 +396,8 @@ public final class TestConstants {
 
     public static final String ACS_URL = "https://localhost:9443/commonauth";
 
+    public static final String AUTHENTICATION_CONTEXT_CLASSES = "Password,Password Protected Transport";
+
     public static final String ACS_INDEX = "123456789";
 
     public static final String IDP_NAME = "secondary";


### PR DESCRIPTION
Fixes https://github.com/wso2/product-is/issues/12887

Improved to use Multiple authentication context classes for SAML IDP so that multiple authentication context classes can be included in SAMLAuthnRequest