### PR TITLE
Fix SAML artifact binding failure due to content type issue

### DIFF
--- a/components/org.wso2.carbon.identity.application.authenticator.samlsso/src/main/java/org/wso2/carbon/identity/application/authenticator/samlsso/artifact/SAMLSSOSoapMessageService.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.samlsso/src/main/java/org/wso2/carbon/identity/application/authenticator/samlsso/artifact/SAMLSSOSoapMessageService.java
@@ -173,7 +173,7 @@ public class SAMLSSOSoapMessageService {
         httpPost.addHeader(SSOConstants.PRAGMA_PARAM_KEY, "no-cache");
         httpPost.addHeader(SSOConstants.CACHE_CONTROL_PARAM_KEY, "no-cache, no-store");
 
-        httpPost.setEntity(new StringEntity(message, ContentType.create(CONTENT_TYPE)));
+        httpPost.setEntity(new StringEntity(message, ContentType.create("text/xml", "UTF-8")));
     }
 
     private static String getResponseBody(HttpResponse response) throws ArtifactResolutionException {


### PR DESCRIPTION
## Changes in this PR
* Fixes https://github.com/wso2/product-is/issues/13026
* Issue was having a `;` in the content type. Using the `ContentType.create(String, String)` method resolved the issue.