### PR TITLE
Support JDK 11 and JDK 17 Compilation

### DIFF
--- a/.github/workflows/pr-builder.yml
+++ b/.github/workflows/pr-builder.yml
@@ -17,12 +17,15 @@ jobs:
   build:
     runs-on: ubuntu-latest
 
+    strategy:
+      matrix:
+        java-version: [ 11, 17 ]
     steps:
       - uses: actions/checkout@v2
-      - name: Set up Adopt JDK 8
+      - name: Set up Adopt JDK 11 and 17
         uses: actions/setup-java@v2
         with:
-          java-version: "8"
+          java-version: ${{ matrix.java-version }}
           distribution: "adopt"
       - name: Cache local Maven repository
         id: cache-maven-m2

--- a/README.md
+++ b/README.md
@@ -1,1 +1,10 @@
 # identity-outbound-auth-samlsso
+
+## Building from the source
+
+If you want to build **identity-outbound-auth-samlsso** from the source code:
+
+1. Install Java 11 (or Java 17)
+2. Install Apache Maven 3.x.x (https://maven.apache.org/download.cgi#)
+3. Get a clone or download the source from this repository (https://github.com/wso2-extensions/identity-outbound-auth-samlsso)
+4. Run the Maven command ``mvn clean install`` from the ``identity-outbound-auth-samlsso`` directory.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,8 @@
-# identity-outbound-auth-samlsso
+## Welcome to the WSO2 Identity Server (IS) identity-outbound-auth-samlsso.
+
+WSO2 IS is one of the best Identity Servers, which enables you to offload your identity and user entitlement management burden totally from your application. It comes with many features, supports many industry standards and most importantly it allows you to extent it according to your security requirements. This repo contains Authenticators written to work with different third party systems.
+
+With WSO2 IS, there are lot of provisioning capabilities available. There are 3 major concepts as Inbound, outbound provisioning and Just-In-Time provisioning. Inbound provisioning means , provisioning users and groups from an external system to IS. Outbound provisioning means , provisioning users from IS to other external systems. JIT provisioning means , once a user tries to login from an external IDP, a user can be created on the fly in IS with JIT. Repos under this account holds such components invlove in communicating with external systems.
 
 ## Building from the source
 

--- a/components/org.wso2.carbon.identity.application.authenticator.samlsso/pom.xml
+++ b/components/org.wso2.carbon.identity.application.authenticator.samlsso/pom.xml
@@ -20,7 +20,7 @@
         <groupId>org.wso2.carbon.identity.outbound.auth.saml2</groupId>
         <artifactId>identity-application-auth-samlsso</artifactId>
         <relativePath>../../pom.xml</relativePath>
-        <version>5.7.1-SNAPSHOT</version>
+        <version>5.8.0-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/components/org.wso2.carbon.identity.application.authenticator.samlsso/pom.xml
+++ b/components/org.wso2.carbon.identity.application.authenticator.samlsso/pom.xml
@@ -241,7 +241,6 @@
                         --add-opens java.xml/jdk.xml.internal=ALL-UNNAMED
                         --add-opens java.base/jdk.internal.util=ALL-UNNAMED
                         --add-opens java.base/java.lang=ALL-UNNAMED
-                        --add-opens java.base/javax.crypto=ALL-UNNAMED
                         --add-opens java.base/java.util=ALL-UNNAMED
                         --add-opens java.base/sun.security=ALL-UNNAMED
                         --add-opens java.base/java.security=ALL-UNNAMED
@@ -249,7 +248,6 @@
                         --add-opens java.base/java.lang.reflect=ALL-UNNAMED
                         --add-opens java.base/sun.security.x509=ALL-UNNAMED
                         --add-opens java.base/java.security.cert=ALL-UNNAMED
-                        --add-opens=java.base/sun.nio.fs=ALL-UNNAMED
                         --add-opens=java.base/sun.nio.fs=ALL-UNNAMED
                         --add-opens=java.base/java.util.stream=ALL-UNNAMED
                     </argLine>

--- a/components/org.wso2.carbon.identity.application.authenticator.samlsso/pom.xml
+++ b/components/org.wso2.carbon.identity.application.authenticator.samlsso/pom.xml
@@ -85,6 +85,11 @@
             <artifactId>org.wso2.carbon.identity.saml.common.util</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.wso2.carbon.identity.framework</groupId>
+            <artifactId>org.wso2.carbon.identity.testutil</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.wso2.orbit.org.opensaml</groupId>
             <artifactId>opensaml</artifactId>
         </dependency>
@@ -129,7 +134,7 @@
         </dependency>
         <dependency>
             <groupId>org.powermock</groupId>
-            <artifactId>powermock-api-mockito</artifactId>
+            <artifactId>powermock-api-mockito2</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -146,6 +151,16 @@
             <groupId>com.h2database</groupId>
             <artifactId>h2</artifactId>
             <version>${h2database.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.sun.xml.ws</groupId>
+            <artifactId>jaxws-ri</artifactId>
+            <type>pom</type>
+        </dependency>
+        <dependency>
+            <groupId>com.sun.xml.parsers</groupId>
+            <artifactId>jaxp-ri</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>
@@ -217,6 +232,27 @@
                     <suiteXmlFiles>
                         <suiteXmlFile>src/test/resources/testng.xml</suiteXmlFile>
                     </suiteXmlFiles>
+                    <systemPropertyVariables>
+                        <jacoco-agent.destfile>target/jacoco.exec</jacoco-agent.destfile>
+                    </systemPropertyVariables>
+                    <useSystemClassLoader>false</useSystemClassLoader>
+                    <argLine>
+                        --add-opens java.base/jdk.internal.loader=ALL-UNNAMED
+                        --add-opens java.xml/jdk.xml.internal=ALL-UNNAMED
+                        --add-opens java.base/jdk.internal.util=ALL-UNNAMED
+                        --add-opens java.base/java.lang=ALL-UNNAMED
+                        --add-opens java.base/javax.crypto=ALL-UNNAMED
+                        --add-opens java.base/java.util=ALL-UNNAMED
+                        --add-opens java.base/sun.security=ALL-UNNAMED
+                        --add-opens java.base/java.security=ALL-UNNAMED
+                        --add-opens java.base/java.io=ALL-UNNAMED
+                        --add-opens java.base/java.lang.reflect=ALL-UNNAMED
+                        --add-opens java.base/sun.security.x509=ALL-UNNAMED
+                        --add-opens java.base/java.security.cert=ALL-UNNAMED
+                        --add-opens=java.base/sun.nio.fs=ALL-UNNAMED
+                        --add-opens=java.base/sun.nio.fs=ALL-UNNAMED
+                        --add-opens=java.base/java.util.stream=ALL-UNNAMED
+                    </argLine>
                 </configuration>
             </plugin>
             <plugin>

--- a/components/org.wso2.carbon.identity.application.authenticator.samlsso/src/test/java/org/wso2/carbon/identity/application/authenticator/samlsso/SAMLSSOAuthenticatorTest.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.samlsso/src/test/java/org/wso2/carbon/identity/application/authenticator/samlsso/SAMLSSOAuthenticatorTest.java
@@ -80,7 +80,7 @@ import static org.wso2.carbon.identity.application.authenticator.samlsso.util.Mo
 /**
  * Unit test cases for SAMLSSOAuthenticator
  */
-@PowerMockIgnore({"javax.xml.datatype.*"})
+@PowerMockIgnore({"javax.xml.datatype.*","org.mockito.*","org.powermock.api.mockito.invocation.*","javax.crypto.Cipher"})
 @PrepareForTest({XPathFactory.class, XMLInputFactory.class, DocumentBuilderFactory.class, IdentityUtil.class,
         DOMImplementationRegistry.class})
 public class SAMLSSOAuthenticatorTest {

--- a/components/org.wso2.carbon.identity.application.authenticator.samlsso/src/test/java/org/wso2/carbon/identity/application/authenticator/samlsso/logout/processor/SAMLLogoutRequestProcessorTest.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.samlsso/src/test/java/org/wso2/carbon/identity/application/authenticator/samlsso/logout/processor/SAMLLogoutRequestProcessorTest.java
@@ -24,6 +24,7 @@ import org.apache.commons.dbcp.BasicDataSource;
 import org.apache.commons.lang.StringUtils;
 import org.mockito.Mock;
 import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.testng.PowerMockTestCase;
 import org.testng.annotations.AfterClass;
@@ -82,6 +83,7 @@ import static org.wso2.carbon.identity.application.common.util.IdentityApplicati
 @PrepareForTest({IdentityDatabaseUtil.class, IdentityProviderManager.class, SAMLSSOAuthenticatorServiceDataHolder.class,
         IdentityCoreServiceComponent.class, AuthenticationRequestCache.class, IdentityContextCache.class,
         ServiceURLBuilder.class, FrameworkUtils.class, IdentityTenantUtil.class, SAMLLogoutUtil.class})
+@PowerMockIgnore({"javax.xml.*", "org.xml.*", "org.w3c.*","javax.crypto.Cipher"})
 @WithH2Database(files = {"dbscripts/h2.sql", "dbscripts/h2-with-tenant-id.sql"})
 public class SAMLLogoutRequestProcessorTest extends PowerMockTestCase {
 
@@ -342,7 +344,7 @@ public class SAMLLogoutRequestProcessorTest extends PowerMockTestCase {
         when(FrameworkUtils.isTenantIdColumnAvailableInFedAuthTable()).thenReturn(Boolean.TRUE);
 
         mockStatic(IdentityTenantUtil.class);
-        when(IdentityTenantUtil.getTenantId(anyString())).thenReturn(1);
+        when(IdentityTenantUtil.getTenantId(nullable(String.class))).thenReturn(1);
 
         mockServiceURLBuilder();
         assertNotNull(processor.process(mockedRequest));
@@ -411,7 +413,7 @@ public class SAMLLogoutRequestProcessorTest extends PowerMockTestCase {
         when(FrameworkUtils.isTenantIdColumnAvailableInFedAuthTable()).thenReturn(Boolean.TRUE);
 
         mockStatic(IdentityTenantUtil.class);
-        when(IdentityTenantUtil.getTenantId(anyString())).thenReturn(1);
+        when(IdentityTenantUtil.getTenantId(nullable(String.class))).thenReturn(1);
 
         mockServiceURLBuilder();
         assertNotNull(processor.process(mockedRequest));

--- a/components/org.wso2.carbon.identity.application.authenticator.samlsso/src/test/java/org/wso2/carbon/identity/application/authenticator/samlsso/logout/processor/SAMLLogoutRequestProcessorTest.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.samlsso/src/test/java/org/wso2/carbon/identity/application/authenticator/samlsso/logout/processor/SAMLLogoutRequestProcessorTest.java
@@ -28,11 +28,14 @@ import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.testng.PowerMockTestCase;
 import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.BeforeTest;
 import org.testng.annotations.Test;
 import org.wso2.carbon.identity.application.authentication.framework.cache.AuthenticationRequestCache;
 import org.wso2.carbon.identity.application.authentication.framework.inbound.IdentityContextCache;
 import org.wso2.carbon.identity.application.authentication.framework.util.FrameworkUtils;
 import org.wso2.carbon.identity.application.authenticator.samlsso.internal.SAMLSSOAuthenticatorServiceDataHolder;
+import org.wso2.carbon.identity.application.authenticator.samlsso.logout.context.SAMLMessageContext;
 import org.wso2.carbon.identity.application.authenticator.samlsso.logout.exception.SAMLLogoutException;
 import org.wso2.carbon.identity.application.authenticator.samlsso.logout.request.SAMLLogoutRequest;
 import org.wso2.carbon.identity.application.authenticator.samlsso.logout.util.SAMLLogoutUtil;
@@ -49,6 +52,7 @@ import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
 import org.wso2.carbon.idp.mgt.IdentityProviderManager;
 import org.wso2.carbon.user.core.service.RealmService;
 import org.wso2.carbon.utils.ConfigurationContextService;
+import org.wso2.carbon.utils.multitenancy.MultitenantConstants;
 
 import java.nio.file.Paths;
 import java.sql.Connection;
@@ -118,6 +122,14 @@ public class SAMLLogoutRequestProcessorTest extends PowerMockTestCase {
 
     @Mock
     private IdentityContextCache mockedIdentityCache;
+
+    @BeforeMethod
+    public void setUp() throws Exception {
+
+        SAMLMessageContext<String, String> samlMessageContext = new SAMLMessageContext<>(mockedRequest,
+                new HashMap<>());
+        when(samlMessageContext.getSAMLLogoutRequest().getTenantDomain()).thenReturn(MultitenantConstants.SUPER_TENANT_DOMAIN_NAME);
+    }
 
     @Test
     public void testProcess() throws Exception {
@@ -344,7 +356,7 @@ public class SAMLLogoutRequestProcessorTest extends PowerMockTestCase {
         when(FrameworkUtils.isTenantIdColumnAvailableInFedAuthTable()).thenReturn(Boolean.TRUE);
 
         mockStatic(IdentityTenantUtil.class);
-        when(IdentityTenantUtil.getTenantId(nullable(String.class))).thenReturn(1);
+        when(IdentityTenantUtil.getTenantId(MultitenantConstants.SUPER_TENANT_DOMAIN_NAME)).thenReturn(1);
 
         mockServiceURLBuilder();
         assertNotNull(processor.process(mockedRequest));
@@ -413,7 +425,7 @@ public class SAMLLogoutRequestProcessorTest extends PowerMockTestCase {
         when(FrameworkUtils.isTenantIdColumnAvailableInFedAuthTable()).thenReturn(Boolean.TRUE);
 
         mockStatic(IdentityTenantUtil.class);
-        when(IdentityTenantUtil.getTenantId(nullable(String.class))).thenReturn(1);
+        when(IdentityTenantUtil.getTenantId(MultitenantConstants.SUPER_TENANT_DOMAIN_NAME)).thenReturn(1);
 
         mockServiceURLBuilder();
         assertNotNull(processor.process(mockedRequest));

--- a/components/org.wso2.carbon.identity.application.authenticator.samlsso/src/test/java/org/wso2/carbon/identity/application/authenticator/samlsso/manager/DefaultSAML2SSOManagerTest.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.samlsso/src/test/java/org/wso2/carbon/identity/application/authenticator/samlsso/manager/DefaultSAML2SSOManagerTest.java
@@ -122,7 +122,7 @@ import static org.wso2.carbon.utils.multitenancy.MultitenantConstants.SUPER_TENA
 /**
  * Unit test cases for DefaultSAML2SSOManager
  */
-@PowerMockIgnore({"javax.xml.datatype.*"})
+@PowerMockIgnore({"javax.xml.datatype.*","org.mockito.*","org.powermock.api.mockito.invocation.*","javax.crypto.Cipher"})
 @PrepareForTest({FileBasedConfigurationBuilder.class, IdentityUtil.class, DocumentBuilderFactory.class,
         KeyStoreManager.class, DOMImplementationRegistry.class, XPathFactory.class, FrameworkUtils.class,
         ServiceURLBuilder.class})

--- a/components/org.wso2.carbon.identity.application.authenticator.samlsso/src/test/java/org/wso2/carbon/identity/application/authenticator/samlsso/manager/X509CredentialImplTest.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.samlsso/src/test/java/org/wso2/carbon/identity/application/authenticator/samlsso/manager/X509CredentialImplTest.java
@@ -21,6 +21,7 @@ import org.apache.commons.collections.CollectionUtils;
 import org.mockito.Mock;
 import org.opensaml.security.credential.UsageType;
 import org.opensaml.security.x509.X509Credential;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.testng.IObjectFactory;
 import org.testng.annotations.BeforeClass;
@@ -57,6 +58,7 @@ import static org.wso2.carbon.identity.common.testng.TestConstants.CARBON_HOST_L
 /**
  * Unit tests for X509CredentialImpl.
  */
+@PowerMockIgnore({"org.mockito.*","org.powermock.api.mockito.invocation.*"})
 @PrepareForTest({KeyStoreManager.class, FrameworkUtils.class})
 public class X509CredentialImplTest {
 

--- a/features/org.wso2.carbon.identity.application.authenticator.samlsso.server.feature/pom.xml
+++ b/features/org.wso2.carbon.identity.application.authenticator.samlsso.server.feature/pom.xml
@@ -22,7 +22,7 @@
         <groupId>org.wso2.carbon.identity.outbound.auth.saml2</groupId>
         <artifactId>identity-application-auth-samlsso</artifactId>
         <relativePath>../../pom.xml</relativePath>
-        <version>5.7.1-SNAPSHOT</version>
+        <version>5.8.0-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/pom.xml
+++ b/pom.xml
@@ -88,6 +88,12 @@
                 <artifactId>org.wso2.carbon.identity.application.authentication.framework</artifactId>
                 <version>${carbon.identity.framework.version}</version>
             </dependency>
+            <dependency>
+                <groupId>org.wso2.carbon.identity.framework</groupId>
+                <artifactId>org.wso2.carbon.identity.testutil</artifactId>
+                <scope>test</scope>
+                <version>${carbon.identity.framework.version}</version>
+            </dependency>
 
             <!--SAML Common Util dependency-->
             <dependency>
@@ -166,7 +172,7 @@
             </dependency>
             <dependency>
                 <groupId>org.powermock</groupId>
-                <artifactId>powermock-api-mockito</artifactId>
+                <artifactId>powermock-api-mockito2</artifactId>
                 <version>${powermock-module-testng.version}</version>
             </dependency>
             <dependency>
@@ -178,6 +184,18 @@
                 <groupId>org.ops4j.pax.logging</groupId>
                 <artifactId>pax-logging-api</artifactId>
                 <version>${pax.logging.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.sun.xml.ws</groupId>
+                <artifactId>jaxws-ri</artifactId>
+                <version>${com.sun.xml.ws.version}</version>
+                <type>pom</type>
+            </dependency>
+            <dependency>
+                <groupId>com.sun.xml.parsers</groupId>
+                <artifactId>jaxp-ri</artifactId>
+                <version>${com.sun.xml.parsers.version}</version>
+                <scope>test</scope>
             </dependency>
         </dependencies>
     </dependencyManagement>
@@ -268,7 +286,7 @@
         <carbon.user.api.imp.pkg.version.range>[1.0.1, 2.0.0)</carbon.user.api.imp.pkg.version.range>
 
         <!--Carbon Identity Framework Version-->
-        <carbon.identity.framework.version>5.20.433</carbon.identity.framework.version>
+        <carbon.identity.framework.version>5.21.7</carbon.identity.framework.version>
         <carbon.identity.framework.imp.pkg.version.range>[5.15.0, 6.0.0)</carbon.identity.framework.imp.pkg.version.range>
 
         <!--SAML Common Util Version-->
@@ -315,14 +333,17 @@
 
         <!-- Unit test versions -->
         <testng.version>6.9.10</testng.version>
-        <jacoco.version>0.7.9</jacoco.version>
-        <maven.surefire.plugin.version>2.18.1</maven.surefire.plugin.version>
-        <slf4j.api.version>1.7.12</slf4j.api.version>
-        <powermock-module-testng.version>1.6.6</powermock-module-testng.version>
+        <jacoco.version>0.8.7</jacoco.version>
+        <maven.surefire.plugin.version>2.22.2</maven.surefire.plugin.version>
+        <slf4j.api.version>1.6.1</slf4j.api.version>
+        <powermock-module-testng.version>2.0.9</powermock-module-testng.version>
         <apache.felix.scr.ds.annotations.version>1.2.4</apache.felix.scr.ds.annotations.version>
         <pax.logging.version>1.11.0</pax.logging.version>
         <imp.package.version.osgi.services>[1.2.0,2.0.0)</imp.package.version.osgi.services>
         <h2database.version>1.4.199</h2database.version>
+
+        <com.sun.xml.ws.version>2.3.5</com.sun.xml.ws.version>
+        <com.sun.xml.parsers.version>1.4.5</com.sun.xml.parsers.version>
     </properties>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.wso2.carbon.identity.outbound.auth.saml2</groupId>
     <artifactId>identity-application-auth-samlsso</artifactId>
-    <version>5.7.1-SNAPSHOT</version>
+    <version>5.8.0-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>WSO2 Carbon - SAML SSO Application Authenticator Feature Aggregator Module</name>
     <description> WSO2 Carbon - Identity Application Authentication SAMLSSO</description>

--- a/pom.xml
+++ b/pom.xml
@@ -286,7 +286,7 @@
         <carbon.user.api.imp.pkg.version.range>[1.0.1, 2.0.0)</carbon.user.api.imp.pkg.version.range>
 
         <!--Carbon Identity Framework Version-->
-        <carbon.identity.framework.version>5.21.7</carbon.identity.framework.version>
+        <carbon.identity.framework.version>5.23.14</carbon.identity.framework.version>
         <carbon.identity.framework.imp.pkg.version.range>[5.15.0, 6.0.0)</carbon.identity.framework.imp.pkg.version.range>
 
         <!--SAML Common Util Version-->

--- a/pom.xml
+++ b/pom.xml
@@ -280,8 +280,8 @@
         <identity.outbound.auth.samlsso.imp.pkg.version.range>[1.0.0, 2.0.0)</identity.outbound.auth.samlsso.imp.pkg.version.range>
 
         <!--Carbon Kernel Version-->
-        <carbon.kernel.version>4.7.0</carbon.kernel.version>
-        <carbon.kernel.feature.version>4.7.0</carbon.kernel.feature.version>
+        <carbon.kernel.version>4.7.1</carbon.kernel.version>
+        <carbon.kernel.feature.version>4.7.1</carbon.kernel.feature.version>
         <carbon.kernel.imp.pkg.version.range>[4.4.0, 5.0.0)</carbon.kernel.imp.pkg.version.range>
         <carbon.user.api.imp.pkg.version.range>[1.0.1, 2.0.0)</carbon.user.api.imp.pkg.version.range>
 


### PR DESCRIPTION
### Purpose

Update the repository to support JDK 11 and JDK 17 compilation.

### When should this PR be merged

After this PR is merged to the main branch, we can't build the branch on JDK 8

### Version checked,

- openjdk "11.0.16.1"
- openjdk "17.0.4.1"

### Related Issue
https://github.com/wso2/product-is/issues/14224