### PR TITLE
Remove SHA1 default usage

### DIFF
--- a/components/org.wso2.carbon.identity.application.authenticator.samlsso/src/main/java/org/wso2/carbon/identity/application/authenticator/samlsso/SAMLSSOAuthenticator.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.samlsso/src/main/java/org/wso2/carbon/identity/application/authenticator/samlsso/SAMLSSOAuthenticator.java
@@ -689,7 +689,7 @@ public class SAMLSSOAuthenticator extends AbstractApplicationAuthenticator
         signatureAlgoOptions.add(IdentityApplicationConstants.XML.SignatureAlgorithm.RSA_SHA512);
 
         signatureAlgo.setOptions(signatureAlgoOptions.toArray(new String[0]));
-        signatureAlgo.setDefaultValue(IdentityApplicationConstants.XML.SignatureAlgorithm.RSA_SHA1);
+        signatureAlgo.setDefaultValue(IdentityApplicationConstants.XML.SignatureAlgorithm.RSA_SHA256);
         configProperties.add(signatureAlgo);
 
         Property digestAlgo = new Property();
@@ -709,7 +709,7 @@ public class SAMLSSOAuthenticator extends AbstractApplicationAuthenticator
         digestAlgoOptions.add(IdentityApplicationConstants.XML.DigestAlgorithm.SHA512);
 
         digestAlgo.setOptions(digestAlgoOptions.toArray(new String[0]));
-        digestAlgo.setDefaultValue(IdentityApplicationConstants.XML.DigestAlgorithm.SHA1);
+        digestAlgo.setDefaultValue(IdentityApplicationConstants.XML.DigestAlgorithm.SHA256);
         configProperties.add(digestAlgo);
 
         Property attributeConsumeIndex = new Property();

--- a/components/org.wso2.carbon.identity.application.authenticator.samlsso/src/main/java/org/wso2/carbon/identity/application/authenticator/samlsso/manager/DefaultSAML2SSOManager.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.samlsso/src/main/java/org/wso2/carbon/identity/application/authenticator/samlsso/manager/DefaultSAML2SSOManager.java
@@ -237,7 +237,7 @@ public class DefaultSAML2SSOManager implements SAML2SSOManager {
             String signatureAlgoProp = properties
                     .get(IdentityApplicationConstants.Authenticator.SAML2SSO.SIGNATURE_ALGORITHM);
             if (StringUtils.isEmpty(signatureAlgoProp)) {
-                signatureAlgoProp = IdentityApplicationConstants.XML.SignatureAlgorithm.RSA_SHA1;
+                signatureAlgoProp = IdentityApplicationConstants.XML.SignatureAlgorithm.RSA_SHA256;
             }
             String signatureAlgo = IdentityApplicationManagementUtil.getXMLSignatureAlgorithms()
                     .get(signatureAlgoProp);
@@ -288,7 +288,7 @@ public class DefaultSAML2SSOManager implements SAML2SSOManager {
         signatureAlgoProp = properties
                 .get(IdentityApplicationConstants.Authenticator.SAML2SSO.SIGNATURE_ALGORITHM);
         if (StringUtils.isEmpty(signatureAlgoProp)) {
-            signatureAlgoProp = IdentityApplicationConstants.XML.SignatureAlgorithm.RSA_SHA1;
+            signatureAlgoProp = IdentityApplicationConstants.XML.SignatureAlgorithm.RSA_SHA256;
         }
         signatureAlgo = IdentityApplicationManagementUtil.getXMLSignatureAlgorithms().get(signatureAlgoProp);
 
@@ -296,7 +296,7 @@ public class DefaultSAML2SSOManager implements SAML2SSOManager {
         digestAlgoProp = properties
                 .get(IdentityApplicationConstants.Authenticator.SAML2SSO.DIGEST_ALGORITHM);
         if (StringUtils.isEmpty(digestAlgoProp)) {
-            digestAlgoProp = IdentityApplicationConstants.XML.DigestAlgorithm.SHA1;
+            digestAlgoProp = IdentityApplicationConstants.XML.DigestAlgorithm.SHA256;
         }
         digestAlgo = IdentityApplicationManagementUtil.getXMLDigestAlgorithms().get(digestAlgoProp);
 

--- a/components/org.wso2.carbon.identity.application.authenticator.samlsso/src/main/java/org/wso2/carbon/identity/application/authenticator/samlsso/util/SSOUtils.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.samlsso/src/main/java/org/wso2/carbon/identity/application/authenticator/samlsso/util/SSOUtils.java
@@ -172,11 +172,11 @@ public class SSOUtils {
         //TODO use StringUtils.isBlank
         if (StringUtils.isEmpty(signatureAlgorithm)) {
             signatureAlgorithm = IdentityApplicationManagementUtil.getXMLSignatureAlgorithms().get(
-                    IdentityApplicationConstants.XML.SignatureAlgorithm.RSA_SHA1);
+                    IdentityApplicationConstants.XML.SignatureAlgorithm.RSA_SHA256);
         }
         if (StringUtils.isEmpty(digestAlgorithm)) {
             digestAlgorithm = IdentityApplicationManagementUtil.getXMLDigestAlgorithms().get(
-                    IdentityApplicationConstants.XML.DigestAlgorithm.SHA1);
+                    IdentityApplicationConstants.XML.DigestAlgorithm.SHA256);
         }
         
         Signature signature = (Signature) buildXMLObject(Signature.DEFAULT_ELEMENT_NAME);
@@ -530,7 +530,7 @@ public class SSOUtils {
             signatureAlgo = properties.get(IdentityApplicationConstants.Authenticator.SAML2SSO.SIGNATURE_ALGORITHM);
         }
         if (StringUtils.isEmpty(signatureAlgo)) {
-            signatureAlgo = IdentityApplicationConstants.XML.SignatureAlgorithm.RSA_SHA1;
+            signatureAlgo = IdentityApplicationConstants.XML.SignatureAlgorithm.RSA_SHA256;
         }
         signatureAlgo = IdentityApplicationManagementUtil.getXMLSignatureAlgorithms().get(signatureAlgo);
         if (log.isDebugEnabled()) {
@@ -546,7 +546,7 @@ public class SSOUtils {
             digestAlgo = properties.get(IdentityApplicationConstants.Authenticator.SAML2SSO.DIGEST_ALGORITHM);
         }
         if (StringUtils.isEmpty(digestAlgo)) {
-            digestAlgo = IdentityApplicationConstants.XML.DigestAlgorithm.SHA1;
+            digestAlgo = IdentityApplicationConstants.XML.DigestAlgorithm.SHA256;
         }
         digestAlgo = IdentityApplicationManagementUtil.getXMLDigestAlgorithms().get(digestAlgo);
         if (log.isDebugEnabled()) {

--- a/components/org.wso2.carbon.identity.application.authenticator.samlsso/src/test/java/org/wso2/carbon/identity/application/authenticator/samlsso/util/SSOUtilsTest.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.samlsso/src/test/java/org/wso2/carbon/identity/application/authenticator/samlsso/util/SSOUtilsTest.java
@@ -209,11 +209,11 @@ public class SSOUtilsTest {
     @Test
     public void testGetSignatureAlgorithm() {
 
-        Assert.assertEquals(SSOUtils.getSignatureAlgorithm(null), TestConstants.SIGNATURE_ALGO_XML_SHA1,
+        Assert.assertEquals(SSOUtils.getSignatureAlgorithm(null), TestConstants.SIGNATURE_ALGO_XML_SHA256,
                 "Returned invalid output");
 
         Map<String, String> properties = new HashMap<>();
-        Assert.assertEquals(SSOUtils.getSignatureAlgorithm(properties), TestConstants.SIGNATURE_ALGO_XML_SHA1,
+        Assert.assertEquals(SSOUtils.getSignatureAlgorithm(properties), TestConstants.SIGNATURE_ALGO_XML_SHA256,
                 "Returned invalid output");
 
         properties.put(TestConstants.SIGNATURE_ALGO, TestConstants.SIGNATURE_ALGO_SHA256);
@@ -225,10 +225,11 @@ public class SSOUtilsTest {
     @Test
     public void testGetDigestAlgorithm() {
 
-        Assert.assertEquals(SSOUtils.getDigestAlgorithm(null), TestConstants.DIGEST_ALGO_XML_SHA1, "Returned invalid output");
+        Assert.assertEquals(SSOUtils.getDigestAlgorithm(null), TestConstants.DIGEST_ALGO_XML_SHA256, "Returned " +
+                "invalid output");
 
         Map<String, String> properties = new HashMap<>();
-        Assert.assertEquals(SSOUtils.getDigestAlgorithm(properties), TestConstants.DIGEST_ALGO_XML_SHA1,
+        Assert.assertEquals(SSOUtils.getDigestAlgorithm(properties), TestConstants.DIGEST_ALGO_XML_SHA256,
                 "Returned invalid output");
 
         properties.put(TestConstants.DIGEST_ALGO, TestConstants.DIGEST_ALGO_SHA256);


### PR DESCRIPTION
## Purpose

The default behavior of our products uses SHA1 which is no longer considered as secure. This PR changes the SHA1 usages of the following flows to SHA256.

- Default Signature algorithm used for signing authentication request to federated IdP (if default is not specified in `deployment.toml`)
- Signature and Digest algorithms used for signing SAML Artifact resolve request (if default is not specified in `deployment.toml`)
- Signing logout response (if default is not specified in `deployment.toml`)
- Default values of Signature Algorithm and Digest Algorithm returned by SAML meta endpoint: https://localhost:9443/api/server/v1/applications/meta/inbound-protocols/saml

## Migration impact
These changes affect only newly created IDPs. 

## Related issues
 
- Issue https://github.com/wso2/product-is/issues/15793

## Related PRs

- PR https://github.com/wso2/carbon-identity-framework/pull/4567
- PR https://github.com/wso2-extensions/identity-inbound-auth-sts/pull/136
- PR https://github.com/wso2-extensions/identity-metadata-saml2/pull/85
- PR https://github.com/wso2-extensions/identity-inbound-auth-oauth/pull/2076
- PR https://github.com/wso2/cipher-tool/pull/78
- PR https://github.com/wso2/carbon-kernel/pull/3574
- PR https://github.com/wso2-extensions/identity-user-account-association/pull/47
- PR https://github.com/wso2-enterprise/asgardeo-website/pull/639
- PR https://github.com/wso2-extensions/identity-governance/pull/707
- PR https://github.com/wso2-extensions/identity-inbound-auth-openid/pull/92
- PR https://github.com/wso2-extensions/identity-outbound-auth-sms-otp/pull/173
- PR https://github.com/wso2-extensions/identity-outbound-auth-email-otp/pull/157

### Documentation

- PR https://github.com/wso2/docs-is/pull/3717