### PR TITLE
Fix saml/slo url path

### DIFF
--- a/components/org.wso2.carbon.identity.application.authenticator.samlsso/src/main/java/org/wso2/carbon/identity/application/authenticator/samlsso/util/SSOConstants.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.samlsso/src/main/java/org/wso2/carbon/identity/application/authenticator/samlsso/util/SSOConstants.java
@@ -54,7 +54,7 @@ public class SSOConstants {
     public static final String SECURITY_KEYSTORE_LOCATION = "Security.KeyStore.Location";
     public static final String SECURITY_KEYSTORE_TYPE = "Security.KeyStore.Type";
 
-    public static final String SAML_SLO_URL = "identity/saml/slo";
+    public static final String SAML_SLO_URL = "/identity/saml/slo";
     public static final Pattern SAML_SLO_ENDPOINT_URL_PATTERN = Pattern.compile("(.*)/identity/saml/slo/?");
 
     public class StatusCodes {


### PR DESCRIPTION
**Issue:**
Fixes https://github.com/wso2/product-is/issues/20275

**Before this fix:**
Since slo URL is given as `identity/saml/slo`, it fails to append the `/` in the commonauth endpoint. It redirects to `https://wso2.is.com/t/carbon.superidentity/saml/slo?sessionDataKey=9eb7504d-83fd-4414-90d1-d7d786ee86dc` endpoint and fails. 

<img width="1497" alt="Screenshot 2024-04-26 at 10 16 59" src="https://github.com/wso2-extensions/identity-outbound-auth-samlsso/assets/17597293/4ba658b7-2e6e-431c-bae2-26ad51a03142">

SAML tracer:
<img width="797" alt="Screenshot 2024-04-26 at 10 18 58" src="https://github.com/wso2-extensions/identity-outbound-auth-samlsso/assets/17597293/6ca157b8-3cfc-4515-ac50-3a2af64d1f42">


**After this fix:**

<img width="1727" alt="Screenshot 2024-04-26 at 10 15 32" src="https://github.com/wso2-extensions/identity-outbound-auth-samlsso/assets/17597293/b12642e8-c925-4fb8-8cf7-0610f847c2a9">


GET https://wso2.is.com/t/carbon.super/identity/saml/slo?sessionDataKey=da6a2a49-523e-42e8-97fd-7c3207e67f5c HTTP/1.1