### PR TITLE
Upgrade SSL context protocol to TLSv1.2

### DIFF
--- a/components/org.wso2.carbon.identity.application.authenticator.samlsso/src/main/java/org/wso2/carbon/identity/application/authenticator/samlsso/artifact/SAMLSSOSoapMessageService.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.samlsso/src/main/java/org/wso2/carbon/identity/application/authenticator/samlsso/artifact/SAMLSSOSoapMessageService.java
@@ -56,9 +56,9 @@ public class SAMLSSOSoapMessageService {
     private static final Log log = LogFactory.getLog(SAMLSSOSoapMessageService.class);
 
     /**
-     * Default ssl protocol for client
+     * Default tls protocol for client
      */
-    private static final String protocol = "TLSv1.2";
+    private static final String TLS_PROTOCOL = "TLSv1.2";
 
     /**
      * Build a SOAP Message.
@@ -154,7 +154,7 @@ public class SAMLSSOSoapMessageService {
 
             char[] kspassphrase = keyStorePassword.toCharArray();
 
-            sslContext = SSLContext.getInstance(protocol);
+            sslContext = SSLContext.getInstance(TLS_PROTOCOL);
             keyManagerFactory = KeyManagerFactory.getInstance("SunX509");
             keyStore = SSOUtils.loadKeyStoreFromFileSystem(keyStorePath, keyStorePassword, keyStoreType);
             keyManagerFactory.init(keyStore, kspassphrase);

--- a/components/org.wso2.carbon.identity.application.authenticator.samlsso/src/main/java/org/wso2/carbon/identity/application/authenticator/samlsso/artifact/SAMLSSOSoapMessageService.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.samlsso/src/main/java/org/wso2/carbon/identity/application/authenticator/samlsso/artifact/SAMLSSOSoapMessageService.java
@@ -56,6 +56,11 @@ public class SAMLSSOSoapMessageService {
     private static final Log log = LogFactory.getLog(SAMLSSOSoapMessageService.class);
 
     /**
+     * Default ssl protocol for client
+     */
+    private static final String protocol = "TLSv1.2";
+
+    /**
      * Build a SOAP Message.
      *
      * @param samlMessage SAMLObject.
@@ -149,7 +154,7 @@ public class SAMLSSOSoapMessageService {
 
             char[] kspassphrase = keyStorePassword.toCharArray();
 
-            sslContext = SSLContext.getInstance("TLS");
+            sslContext = SSLContext.getInstance(protocol);
             keyManagerFactory = KeyManagerFactory.getInstance("SunX509");
             keyStore = SSOUtils.loadKeyStoreFromFileSystem(keyStorePath, keyStorePassword, keyStoreType);
             keyManagerFactory.init(keyStore, kspassphrase);


### PR DESCRIPTION
## Purpose

> The SSL context protocol should be upgraded to a more secure protocol to fix "Selection of Less-Secure Algorithm During Negotiation" security vulnerabilities.

## Related Issue

- https://github.com/wso2-enterprise/wso2-iam-internal/issues/1568
- https://github.com/wso2-enterprise/security-internals/issues/917