### PR TITLE
Add SAML2 Outbound Request Attribute ProviderName

### DIFF
--- a/components/org.wso2.carbon.identity.application.authenticator.samlsso/src/main/java/org/wso2/carbon/identity/application/authenticator/samlsso/manager/DefaultSAML2SSOManager.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.samlsso/src/main/java/org/wso2/carbon/identity/application/authenticator/samlsso/manager/DefaultSAML2SSOManager.java
@@ -129,6 +129,7 @@ import javax.servlet.http.HttpServletRequest;
 import static org.apache.commons.collections.CollectionUtils.isNotEmpty;
 import static org.opensaml.saml.saml2.core.StatusCode.SUCCESS;
 import static org.wso2.carbon.CarbonConstants.AUDIT_LOG;
+import static org.wso2.carbon.identity.application.authenticator.samlsso.util.SSOConstants.AUTHN_REQUEST_PROVIDER_NAME;
 
 public class DefaultSAML2SSOManager implements SAML2SSOManager {
 
@@ -760,6 +761,8 @@ public class DefaultSAML2SSOManager implements SAML2SSOManager {
         authRequest.setForceAuthn(isForceAuthenticate(context));
         authRequest.setIsPassive(isPassive);
         authRequest.setIssueInstant(issueInstant);
+        String providerName = properties.get(AUTHN_REQUEST_PROVIDER_NAME);
+        authRequest.setProviderName(providerName);
 
         String includeProtocolBindingProp = properties
                 .get(IdentityApplicationConstants.Authenticator.SAML2SSO.INCLUDE_PROTOCOL_BINDING);

--- a/components/org.wso2.carbon.identity.application.authenticator.samlsso/src/main/java/org/wso2/carbon/identity/application/authenticator/samlsso/util/SSOConstants.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.samlsso/src/main/java/org/wso2/carbon/identity/application/authenticator/samlsso/util/SSOConstants.java
@@ -57,6 +57,8 @@ public class SSOConstants {
     public static final String SAML_SLO_URL = "/identity/saml/slo";
     public static final Pattern SAML_SLO_ENDPOINT_URL_PATTERN = Pattern.compile("(.*)/identity/saml/slo/?");
 
+    public static final String AUTHN_REQUEST_PROVIDER_NAME = "AuthnReqProviderName";
+
     public class StatusCodes {
         private StatusCodes() {
 


### PR DESCRIPTION
## Purpose

Adds the functionality for the SAML2 Outbound Request attribute ProviderName.

<img width="755" alt="Screenshot 2024-12-19 at 13 07 31" src="https://github.com/user-attachments/assets/cadcee49-1426-4a6b-9cf8-f64741293ca5" />

This supports getting the ProviderName via the `Authentication Request Provider Name` configuration in the SAML connection.

### Related Issues

- https://github.com/wso2/product-is/issues/21536

### Related PRs

- https://github.com/wso2/identity-apps/pull/7225