### PR TITLE
Update SAML connection ProviderName config name

### DIFF
--- a/components/org.wso2.carbon.identity.application.authenticator.samlsso/src/main/java/org/wso2/carbon/identity/application/authenticator/samlsso/SAMLSSOAuthenticator.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.samlsso/src/main/java/org/wso2/carbon/identity/application/authenticator/samlsso/SAMLSSOAuthenticator.java
@@ -71,6 +71,7 @@ import static org.wso2.carbon.identity.application.authenticator.samlsso.util.SS
 import static org.wso2.carbon.identity.application.authenticator.samlsso.util.SSOConstants.LogConstants.ActionIDs.PROCESS_AUTHENTICATION_RESPONSE;
 import static org.wso2.carbon.identity.application.authenticator.samlsso.util.SSOConstants.LogConstants.ActionIDs.INITIATE_OUTBOUND_AUTH_REQUEST;
 import static org.wso2.carbon.identity.application.authenticator.samlsso.util.SSOConstants.LogConstants.OUTBOUND_AUTH_SAMLSSO_SERVICE;
+import static org.wso2.carbon.identity.application.authenticator.samlsso.util.SSOConstants.SAML_AUTHN_REQUEST_PROVIDER_NAME;
 import static org.wso2.carbon.identity.base.IdentityConstants.FEDERATED_IDP_SESSION_ID;
 
 public class SAMLSSOAuthenticator extends AbstractApplicationAuthenticator
@@ -956,6 +957,15 @@ public class SAMLSSOAuthenticator extends AbstractApplicationAuthenticator
         signatureAlgorithmPost.setType("string");
         signatureAlgorithmPost.setDisplayOrder(0);
         configProperties.add(signatureAlgorithmPost);
+
+        Property authnReqProviderName = new Property();
+        authnReqProviderName.setName(SAML_AUTHN_REQUEST_PROVIDER_NAME);
+        authnReqProviderName.setDisplayName("Authentication Request Provider Name");
+        authnReqProviderName.setRequired(false);
+        authnReqProviderName.setDescription("The human-readable name of the requester");
+        authnReqProviderName.setType("string");
+        selectMode.setDisplayOrder(35);
+        configProperties.add(authnReqProviderName);
 
         return configProperties;
     }

--- a/components/org.wso2.carbon.identity.application.authenticator.samlsso/src/main/java/org/wso2/carbon/identity/application/authenticator/samlsso/manager/DefaultSAML2SSOManager.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.samlsso/src/main/java/org/wso2/carbon/identity/application/authenticator/samlsso/manager/DefaultSAML2SSOManager.java
@@ -129,7 +129,7 @@ import javax.servlet.http.HttpServletRequest;
 import static org.apache.commons.collections.CollectionUtils.isNotEmpty;
 import static org.opensaml.saml.saml2.core.StatusCode.SUCCESS;
 import static org.wso2.carbon.CarbonConstants.AUDIT_LOG;
-import static org.wso2.carbon.identity.application.authenticator.samlsso.util.SSOConstants.AUTHN_REQUEST_PROVIDER_NAME;
+import static org.wso2.carbon.identity.application.authenticator.samlsso.util.SSOConstants.SAML_AUTHN_REQUEST_PROVIDER_NAME;
 
 public class DefaultSAML2SSOManager implements SAML2SSOManager {
 
@@ -761,7 +761,7 @@ public class DefaultSAML2SSOManager implements SAML2SSOManager {
         authRequest.setForceAuthn(isForceAuthenticate(context));
         authRequest.setIsPassive(isPassive);
         authRequest.setIssueInstant(issueInstant);
-        String providerName = properties.get(AUTHN_REQUEST_PROVIDER_NAME);
+        String providerName = properties.get(SAML_AUTHN_REQUEST_PROVIDER_NAME);
         authRequest.setProviderName(providerName);
 
         String includeProtocolBindingProp = properties

--- a/components/org.wso2.carbon.identity.application.authenticator.samlsso/src/main/java/org/wso2/carbon/identity/application/authenticator/samlsso/util/SSOConstants.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.samlsso/src/main/java/org/wso2/carbon/identity/application/authenticator/samlsso/util/SSOConstants.java
@@ -57,7 +57,7 @@ public class SSOConstants {
     public static final String SAML_SLO_URL = "/identity/saml/slo";
     public static final Pattern SAML_SLO_ENDPOINT_URL_PATTERN = Pattern.compile("(.*)/identity/saml/slo/?");
 
-    public static final String AUTHN_REQUEST_PROVIDER_NAME = "AuthnReqProviderName";
+    public static final String SAML_AUTHN_REQUEST_PROVIDER_NAME = "samlAuthnRequestProviderName";
 
     public class StatusCodes {
         private StatusCodes() {


### PR DESCRIPTION
## Purpose

Adds the meta information the ProviderName config to be used in the REST API and updates the ProviderName config name.

## Related Issues

- https://github.com/wso2/product-is/issues/21536

## Related PR

- https://github.com/wso2/identity-apps/pull/7302
- https://github.com/wso2-extensions/identity-outbound-auth-samlsso/pull/182