### PR TITLE
Fix the multi attribute separator usage

### DIFF
--- a/components/org.wso2.carbon.identity.application.authenticator.samlsso/pom.xml
+++ b/components/org.wso2.carbon.identity.application.authenticator.samlsso/pom.xml
@@ -222,13 +222,7 @@
                             org.wso2.carbon.identity.organization.management.service.util; version="${org.wso2.identity.organization.mgt.core.imp.pkg.version.range}",
                             org.wso2.carbon.identity.organization.management.service.exception; version="${org.wso2.identity.organization.mgt.core.imp.pkg.version.range}",
                             org.osgi.service.component.*;version="${imp.package.version.osgi.services}",
-                            org.xml.sax,
-                            org.wso2.carbon.identity.configuration.mgt.core;
-                            version="${carbon.identity.framework.imp.pkg.version.range}",
-                            org.wso2.carbon.identity.configuration.mgt.core.model;
-                            version="${carbon.identity.framework.imp.pkg.version.range}",
-                            org.wso2.carbon.identity.configuration.mgt.core.exception;
-                            version="${carbon.identity.framework.imp.pkg.version.range}",
+                            org.xml.sax
                         </Import-Package>
                         <Export-Package>
                             !org.wso2.carbon.identity.application.authenticator.samlsso.internal,

--- a/components/org.wso2.carbon.identity.application.authenticator.samlsso/src/main/java/org/wso2/carbon/identity/application/authenticator/samlsso/internal/SAMLSSOAuthenticatorServiceComponent.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.samlsso/src/main/java/org/wso2/carbon/identity/application/authenticator/samlsso/internal/SAMLSSOAuthenticatorServiceComponent.java
@@ -37,7 +37,6 @@ import org.wso2.carbon.identity.application.authenticator.samlsso.logout.process
 import org.wso2.carbon.identity.application.authenticator.samlsso.logout.processor.SAMLLogoutResponseProcessor;
 import org.wso2.carbon.identity.application.authenticator.samlsso.logout.request.SAMLLogoutRequestFactory;
 import org.wso2.carbon.identity.application.authenticator.samlsso.logout.response.SAMLLogoutResponseFactory;
-import org.wso2.carbon.identity.configuration.mgt.core.ConfigurationManager;
 import org.wso2.carbon.identity.core.util.IdentityIOStreamUtils;
 import org.wso2.carbon.identity.organization.management.service.OrganizationManager;
 import org.wso2.carbon.user.core.service.RealmService;
@@ -162,29 +161,6 @@ public class SAMLSSOAuthenticatorServiceComponent {
     protected void unsetOrganizationManager(OrganizationManager organizationManager) {
 
         SAMLSSOAuthenticatorServiceDataHolder.getInstance().setOrganizationManager(null);
-    }
-
-    @Reference(
-            name = "resource.configuration.manager",
-            service = ConfigurationManager.class,
-            cardinality = ReferenceCardinality.MANDATORY,
-            policy = ReferencePolicy.DYNAMIC,
-            unbind = "unregisterConfigurationManager"
-    )
-    protected void registerConfigurationManager(ConfigurationManager configurationManager) {
-
-        if (log.isDebugEnabled()) {
-            log.debug("Setting the configuration manager in SAML SSO authenticator service bundle.");
-        }
-        SAMLSSOAuthenticatorServiceDataHolder.getInstance().setConfigurationManager(configurationManager);
-    }
-
-    protected void unregisterConfigurationManager(ConfigurationManager configurationManager) {
-
-        if (log.isDebugEnabled()) {
-            log.debug("Unsetting the configuration manager in SAML SSO authenticator service bundle.");
-        }
-        SAMLSSOAuthenticatorServiceDataHolder.getInstance().setConfigurationManager(null);
     }
 
     public static String getPostPage() {

--- a/components/org.wso2.carbon.identity.application.authenticator.samlsso/src/main/java/org/wso2/carbon/identity/application/authenticator/samlsso/internal/SAMLSSOAuthenticatorServiceDataHolder.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.samlsso/src/main/java/org/wso2/carbon/identity/application/authenticator/samlsso/internal/SAMLSSOAuthenticatorServiceDataHolder.java
@@ -19,7 +19,6 @@
 package org.wso2.carbon.identity.application.authenticator.samlsso.internal;
 
 import org.wso2.carbon.base.api.ServerConfigurationService;
-import org.wso2.carbon.identity.configuration.mgt.core.ConfigurationManager;
 import org.wso2.carbon.identity.organization.management.service.OrganizationManager;
 import org.wso2.carbon.user.core.service.RealmService;
 
@@ -33,7 +32,6 @@ public class SAMLSSOAuthenticatorServiceDataHolder {
     private RealmService realmService;
     private ServerConfigurationService serverConfigurationService;
     private OrganizationManager organizationManager;
-    private ConfigurationManager configurationManager = null;
 
     public static SAMLSSOAuthenticatorServiceDataHolder getInstance() {
 
@@ -72,15 +70,5 @@ public class SAMLSSOAuthenticatorServiceDataHolder {
     public void setOrganizationManager(OrganizationManager organizationManager) {
 
         this.organizationManager = organizationManager;
-    }
-
-    public void setConfigurationManager(ConfigurationManager configurationManager) {
-
-        this.configurationManager = configurationManager;
-    }
-
-    public ConfigurationManager getConfigurationManager() {
-
-        return configurationManager;
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -291,7 +291,8 @@
         <carbon.user.api.imp.pkg.version.range>[1.0.1, 2.0.0)</carbon.user.api.imp.pkg.version.range>
 
         <!--Carbon Identity Framework Version-->
-        <carbon.identity.framework.version>5.25.260</carbon.identity.framework.version>
+        <!-- TODO: Bump the correct version after merging dependent PR.-->
+        <carbon.identity.framework.version>7.8.123-SNAPSHOT</carbon.identity.framework.version>
         <carbon.identity.framework.imp.pkg.version.range>[5.15.0, 8.0.0)</carbon.identity.framework.imp.pkg.version.range>
 
         <identity.organization.management.core.version>1.0.85</identity.organization.management.core.version>


### PR DESCRIPTION
Revert the temporary fix done in https://github.com/wso2-extensions/identity-outbound-auth-samlsso/pull/184 and fix the usages vith https://github.com/wso2/carbon-identity-framework/pull/6697 preserving the backward compatibility.

### Related Issue
- https://github.com/wso2/product-is/issues/23873

### Related PRs
- https://github.com/wso2/carbon-identity-framework/pull/6697
- https://github.com/wso2-extensions/identity-inbound-auth-saml/pull/442