### PR TITLE
Introduce support for a loader-only HTML page for SAML intermediate POST request handling

### DIFF
--- a/components/org.wso2.carbon.identity.application.authenticator.samlsso/src/main/java/org/wso2/carbon/identity/application/authenticator/samlsso/internal/SAMLSSOAuthenticatorServiceComponent.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.samlsso/src/main/java/org/wso2/carbon/identity/application/authenticator/samlsso/internal/SAMLSSOAuthenticatorServiceComponent.java
@@ -37,8 +37,10 @@ import org.wso2.carbon.identity.application.authenticator.samlsso.logout.process
 import org.wso2.carbon.identity.application.authenticator.samlsso.logout.processor.SAMLLogoutResponseProcessor;
 import org.wso2.carbon.identity.application.authenticator.samlsso.logout.request.SAMLLogoutRequestFactory;
 import org.wso2.carbon.identity.application.authenticator.samlsso.logout.response.SAMLLogoutResponseFactory;
+import org.wso2.carbon.identity.application.authenticator.samlsso.util.SSOConstants;
 import org.wso2.carbon.identity.configuration.mgt.core.ConfigurationManager;
 import org.wso2.carbon.identity.core.util.IdentityIOStreamUtils;
+import org.wso2.carbon.identity.core.util.IdentityUtil;
 import org.wso2.carbon.identity.organization.management.service.OrganizationManager;
 import org.wso2.carbon.user.core.service.RealmService;
 import org.wso2.carbon.utils.CarbonUtils;
@@ -83,7 +85,10 @@ public class SAMLSSOAuthenticatorServiceComponent {
             ctxt.getBundleContext()
                     .registerService(IdentityProcessor.class.getName(), new SAMLLogoutResponseProcessor(), null);
 
-            postPagePath = CarbonUtils.getCarbonHome() + File.separator + "repository" + File.separator + "resources" + File.separator + "identity" + File.separator + "pages" + File.separator + "samlsso_federate.html";
+            String htmlPageToUse =
+                    useIntermediateLoaderPage() ? "samlsso_federate_loader.html" : "samlsso_federate.html";
+            postPagePath = CarbonUtils.getCarbonHome() + File.separator + "repository" + File.separator + "resources" +
+                    File.separator + "identity" + File.separator + "pages" + File.separator + htmlPageToUse;
             fis = new FileInputStream(new File(postPagePath));
             postPage = new Scanner(fis, "UTF-8").useDelimiter("\\A").next();
             if (log.isDebugEnabled()) {
@@ -189,6 +194,21 @@ public class SAMLSSOAuthenticatorServiceComponent {
 
     public static String getPostPage() {
         return postPage;
+    }
+
+    /**
+     * If this configuration is set to true, SAML POST request will be sent using an intermediate page that
+     * only contains a loader icon as the visual component
+     * (Ref: repository/resources/identity/pages/samlsso_federate_loader.html).
+     * Otherwise, SAML POST request will be sent using the existing SAML SSO federate page which contains
+     * additional text components (Ref: repository/resources/identity/pages/samlsso_federate.html).
+     *
+     * @return true if the configuration is set to true, false otherwise.
+     */
+    private boolean useIntermediateLoaderPage() {
+
+        return Boolean.parseBoolean(IdentityUtil.getProperty(
+                SSOConstants.ServerConfig.USE_INTERMEDIATE_LOADER_PAGE_CONFIG_NAME));
     }
 }
 

--- a/components/org.wso2.carbon.identity.application.authenticator.samlsso/src/main/java/org/wso2/carbon/identity/application/authenticator/samlsso/util/SSOConstants.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.samlsso/src/main/java/org/wso2/carbon/identity/application/authenticator/samlsso/util/SSOConstants.java
@@ -85,6 +85,9 @@ public class SSOConstants {
 
         public static final String HTTPS_PROXY_HOST = "HTTPS_PROXY_HOST";
         public static final String HTTPS_PROXY_PORT = "HTTPS_PROXY_PORT";
+
+        public static final String USE_INTERMEDIATE_LOADER_PAGE_CONFIG_NAME =
+                "BrandingConfiguration.UseIntermediateLoaderPage";
     }
 
     /**

--- a/components/org.wso2.carbon.identity.application.authenticator.samlsso/src/test/java/org/wso2/carbon/identity/application/authenticator/samlsso/internal/SAMLSSOAuthenticatorServiceComponentTest.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.samlsso/src/test/java/org/wso2/carbon/identity/application/authenticator/samlsso/internal/SAMLSSOAuthenticatorServiceComponentTest.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.application.authenticator.samlsso.internal;
+
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.reflect.Whitebox;
+import org.testng.IObjectFactory;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.ObjectFactory;
+import org.testng.annotations.Test;
+import org.wso2.carbon.identity.application.authenticator.samlsso.util.SSOConstants;
+import org.wso2.carbon.identity.core.util.IdentityUtil;
+
+import static org.powermock.api.mockito.PowerMockito.mockStatic;
+import static org.powermock.api.mockito.PowerMockito.when;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+
+/**
+ * Unit test cases for SAMLSSOAuthenticatorServiceComponent.
+ */
+@PowerMockIgnore({"javax.xml.datatype.*", "org.mockito.*", "org.powermock.api.mockito.invocation.*",
+        "javax.crypto.Cipher"})
+@PrepareForTest({IdentityUtil.class})
+public class SAMLSSOAuthenticatorServiceComponentTest {
+
+    @DataProvider(name = "intermediateLoaderPageConfigProvider")
+    public Object[][] intermediateLoaderPageConfigProvider() {
+
+        return new Object[][] {
+                // { configValue, expectedResult }
+                {"true", true},
+                {"True", true},
+                {"TRUE", true},
+                {"false", false},
+                {"False", false},
+                {"FALSE", false},
+                {null, false},
+                {"", false},
+                {"invalid", false}
+        };
+    }
+
+    @Test(dataProvider = "intermediateLoaderPageConfigProvider",
+            description = "Test useIntermediateLoaderPage with various config values")
+    public void testUseIntermediateLoaderPage(String configValue, boolean expected) throws Exception {
+
+        mockStatic(IdentityUtil.class);
+        when(IdentityUtil.getProperty(SSOConstants.ServerConfig.USE_INTERMEDIATE_LOADER_PAGE_CONFIG_NAME))
+                .thenReturn(configValue);
+
+        SAMLSSOAuthenticatorServiceComponent component = new SAMLSSOAuthenticatorServiceComponent();
+        boolean result = Whitebox.invokeMethod(component, "useIntermediateLoaderPage");
+
+        if (expected) {
+            assertTrue(result, "Expected useIntermediateLoaderPage() to return true for config value: " + configValue);
+        } else {
+            assertFalse(result,
+                    "Expected useIntermediateLoaderPage() to return false for config value: " + configValue);
+        }
+    }
+
+    @ObjectFactory
+    public IObjectFactory getObjectFactory() {
+
+        return new org.powermock.modules.testng.PowerMockObjectFactory();
+    }
+}

--- a/components/org.wso2.carbon.identity.application.authenticator.samlsso/src/test/resources/testng.xml
+++ b/components/org.wso2.carbon.identity.application.authenticator.samlsso/src/test/resources/testng.xml
@@ -22,6 +22,7 @@
         <classes>
             <class name="org.wso2.carbon.identity.application.authenticator.samlsso.util.SSOUtilsTest"/>
             <class name="org.wso2.carbon.identity.application.authenticator.samlsso.SAMLSSOAuthenticatorTest"/>
+            <class name="org.wso2.carbon.identity.application.authenticator.samlsso.internal.SAMLSSOAuthenticatorServiceComponentTest"/>
             <class name="org.wso2.carbon.identity.application.authenticator.samlsso.manager.X509CredentialImplTest"/>
             <class name="org.wso2.carbon.identity.application.authenticator.samlsso.manager.DefaultSAML2SSOManagerTest"/>
             <class name="org.wso2.carbon.identity.application.authenticator.samlsso.artifact.SAMLSSOArtifactResolutionServiceTest"/>
@@ -39,4 +40,3 @@
         </classes>
     </test>
 </suite>
-

--- a/features/org.wso2.carbon.identity.application.authenticator.samlsso.server.feature/pom.xml
+++ b/features/org.wso2.carbon.identity.application.authenticator.samlsso.server.feature/pom.xml
@@ -118,6 +118,7 @@
                                     <includes>
                                         <include>p2.inf</include>
                                         <include>samlsso_federate.html</include>
+                                        <include>samlsso_federate_loader.html</include>
                                     </includes>
                                 </resource>
                             </resources>

--- a/features/org.wso2.carbon.identity.application.authenticator.samlsso.server.feature/resources/p2.inf
+++ b/features/org.wso2.carbon.identity.application.authenticator.samlsso.server.feature/resources/p2.inf
@@ -1,2 +1,3 @@
 instructions.configure = \
 org.eclipse.equinox.p2.touchpoint.natives.copy(source:${installFolder}/../features/org.wso2.carbon.identity.application.authenticator.samlsso.server_${feature.version}/samlsso_federate.html,target:${installFolder}/../../resources/identity/pages/samlsso_federate.html,overwrite:true); \
+org.eclipse.equinox.p2.touchpoint.natives.copy(source:${installFolder}/../features/org.wso2.carbon.identity.application.authenticator.samlsso.server_${feature.version}/samlsso_federate_loader.html,target:${installFolder}/../../resources/identity/pages/samlsso_federate_loader.html,overwrite:true); \

--- a/features/org.wso2.carbon.identity.application.authenticator.samlsso.server.feature/resources/samlsso_federate_loader.html
+++ b/features/org.wso2.carbon.identity.application.authenticator.samlsso.server.feature/resources/samlsso_federate_loader.html
@@ -1,0 +1,79 @@
+<!DOCTYPE html>
+
+<!--
+  ~ Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+  ~
+  ~ WSO2 LLC. licenses this file to you under the Apache License,
+  ~ Version 2.0 (the "License"); you may not use this file except
+  ~ in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+-->
+
+<!--
+  ~ This file is used for sending SAML requests using the POST binding. 
+  ~  
+  ~ Please note that following are placeholders in this file:
+  ~  
+  ~ 1. $url : this will be replaced with the endpoint URL
+  ~  
+  ~ 2. $params: this will be replaced with the actual request parameters 
+  ~              such as SAMLRequest and RelayState. They will be inserted
+  ~              as hidden input fields of the form. 
+  ~  
+  ~ Make sure to leave these placeholders intact when customizations are
+  ~ done to this page.
+-->
+
+<html>
+
+<head>
+    <title>Redirecting</title>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+
+    <style>
+        body {
+            margin: 0;
+            padding: 0;
+            height: 100vh;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            background: #fff;
+        }
+
+        .loader {
+            border: 2px solid #f3f3f3; /* Light grey */
+            border-top: 2px solid #838383; /* Dark grey */
+            border-radius: 50%;
+            width: 24px;
+            height: 24px;
+            animation: spin 2s linear infinite;
+        }
+
+        @keyframes spin {
+            0% { transform: rotate(0deg); }
+            100% { transform: rotate(360deg); }
+        }
+    </style>
+</head>
+
+<body onload="javascript:document.getElementById('samlsso-federate-form').submit()">
+    <div>
+        <div class="loader"></div>
+        <form id="samlsso-federate-form" method="post" action="$url">
+            <!--$params-->
+        </form>
+    </div>
+</body>
+
+</html>

--- a/features/org.wso2.carbon.identity.application.authenticator.samlsso.server.feature/src/main/resources/p2.inf
+++ b/features/org.wso2.carbon.identity.application.authenticator.samlsso.server.feature/src/main/resources/p2.inf
@@ -1,2 +1,3 @@
 instructions.configure = \
 org.eclipse.equinox.p2.touchpoint.natives.copy(source:${installFolder}/../features/org.wso2.carbon.identity.application.authenticator.samlsso.server_${feature.version}/samlsso_federate.html,target:${installFolder}/../../resources/identity/pages/samlsso_federate.html,overwrite:true); \
+org.eclipse.equinox.p2.touchpoint.natives.copy(source:${installFolder}/../features/org.wso2.carbon.identity.application.authenticator.samlsso.server_${feature.version}/samlsso_federate_loader.html,target:${installFolder}/../../resources/identity/pages/samlsso_federate_loader.html,overwrite:true); \

--- a/features/org.wso2.carbon.identity.application.authenticator.samlsso.server.feature/src/main/resources/samlsso_federate_loader.html
+++ b/features/org.wso2.carbon.identity.application.authenticator.samlsso.server.feature/src/main/resources/samlsso_federate_loader.html
@@ -1,0 +1,79 @@
+<!DOCTYPE html>
+
+<!--
+  ~ Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+  ~
+  ~ WSO2 LLC. licenses this file to you under the Apache License,
+  ~ Version 2.0 (the "License"); you may not use this file except
+  ~ in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+-->
+
+<!--
+  ~ This file is used for sending SAML requests using the POST binding. 
+  ~  
+  ~ Please note that following are placeholders in this file:
+  ~  
+  ~ 1. $url : this will be replaced with the endpoint URL
+  ~  
+  ~ 2. $params: this will be replaced with the actual request parameters 
+  ~              such as SAMLRequest and RelayState. They will be inserted
+  ~              as hidden input fields of the form. 
+  ~  
+  ~ Make sure to leave these placeholders intact when customizations are
+  ~ done to this page.
+-->
+
+<html>
+
+<head>
+    <title>Redirecting</title>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+
+    <style>
+        body {
+            margin: 0;
+            padding: 0;
+            height: 100vh;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            background: #fff;
+        }
+
+        .loader {
+            border: 2px solid #f3f3f3; /* Light grey */
+            border-top: 2px solid #838383; /* Dark grey */
+            border-radius: 50%;
+            width: 24px;
+            height: 24px;
+            animation: spin 2s linear infinite;
+        }
+
+        @keyframes spin {
+            0% { transform: rotate(0deg); }
+            100% { transform: rotate(360deg); }
+        }
+    </style>
+</head>
+
+<body onload="javascript:document.getElementById('samlsso-federate-form').submit()">
+    <div>
+        <div class="loader"></div>
+        <form id="samlsso-federate-form" method="post" action="$url">
+            <!--$params-->
+        </form>
+    </div>
+</body>
+
+</html>


### PR DESCRIPTION
### Purpose
This introduces a new page, `repository/resources/identity/pages/samlsso_federate_loader.html`, which displays only a loading indicator without any branded colors, logos, or text. This page can be used as an alternative to `repository/resources/identity/pages/samlsso_federate.html`.

To preserve backward compatibility, this behavior is controlled via a configuration. When the configuration is enabled, this page will be used as the SAML SSO response redirection page. The default value is `false`.

```bash
[branding_configuration]
use_intermediate_loader_page = true
```

### Related Issue
- https://github.com/wso2/product-is/issues/26441