### PR TITLE
Bump the identity framework version

### DIFF
--- a/components/org.wso2.carbon.identity.application.authenticator.samlsso/src/test/java/org/wso2/carbon/identity/application/authenticator/samlsso/logout/processor/SAMLLogoutRequestProcessorTest.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.samlsso/src/test/java/org/wso2/carbon/identity/application/authenticator/samlsso/logout/processor/SAMLLogoutRequestProcessorTest.java
@@ -43,7 +43,7 @@ import org.wso2.carbon.identity.application.common.model.Property;
 import org.wso2.carbon.identity.common.testng.WithCarbonHome;
 import org.wso2.carbon.identity.common.testng.WithH2Database;
 import org.wso2.carbon.identity.core.ServiceURLBuilder;
-import org.wso2.carbon.identity.core.internal.IdentityCoreServiceComponent;
+import org.wso2.carbon.identity.core.internal.component.IdentityCoreServiceComponent;
 import org.wso2.carbon.identity.core.util.IdentityDatabaseUtil;
 import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
 import org.wso2.carbon.idp.mgt.IdentityProviderManagementException;

--- a/pom.xml
+++ b/pom.xml
@@ -296,7 +296,7 @@
         <carbon.user.api.imp.pkg.version.range>[1.0.1, 2.0.0)</carbon.user.api.imp.pkg.version.range>
 
         <!--Carbon Identity Framework Version-->
-        <carbon.identity.framework.version>5.25.260</carbon.identity.framework.version>
+        <carbon.identity.framework.version>7.10.58</carbon.identity.framework.version>
         <carbon.identity.framework.imp.pkg.version.range>[5.15.0, 8.0.0)</carbon.identity.framework.imp.pkg.version.range>
 
         <identity.organization.management.core.version>1.0.85</identity.organization.management.core.version>
@@ -345,7 +345,7 @@
         <maven.buildnumber.plugin.version>1.4</maven.buildnumber.plugin.version>
 
         <!-- Unit test versions -->
-        <testng.version>6.9.10</testng.version>
+        <testng.version>7.10.1</testng.version>
         <jacoco.version>0.8.12</jacoco.version>
         <maven.surefire.plugin.version>2.22.2</maven.surefire.plugin.version>
         <slf4j.api.version>1.6.1</slf4j.api.version>


### PR DESCRIPTION
### Purpose
This pull request updates dependencies to newer versions and fixes a package import to align with recent changes in the codebase. The main focus is on keeping the project up to date with the latest library versions and maintaining compatibility.

**Dependency version upgrades:**

* Upgraded the `carbon.identity.framework.version` from `5.25.260` to `7.10.58` in `pom.xml`, ensuring compatibility with the latest features and security updates.
* Updated the `testng.version` from `6.9.10` to `7.10.1` in `pom.xml` to use the latest version of the TestNG testing framework.

**Codebase maintenance:**

* Fixed the import statement in `SAMLLogoutRequestProcessorTest.java` to use `org.wso2.carbon.identity.core.internal.component.IdentityCoreServiceComponent` instead of the outdated package path.

### Related Issue
- https://github.com/wso2/product-is/issues/26845