### PR TITLE
Support nested assertions in SAML response

### DIFF
--- a/components/org.wso2.carbon.identity.application.authenticator.samlsso/src/main/java/org/wso2/carbon/identity/application/authenticator/samlsso/manager/DefaultSAML2SSOManager.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.samlsso/src/main/java/org/wso2/carbon/identity/application/authenticator/samlsso/manager/DefaultSAML2SSOManager.java
@@ -1059,11 +1059,21 @@ public class DefaultSAML2SSOManager implements SAML2SSOManager {
                     ErrorMessages.INVALID_SCHEMA_FOR_THE_SAML_2_RESPONSE.getMessage());
         }
 
-        // Checking for multiple Assertions. This is done to thwart possible XSW attacks.
-        NodeList assertionList = response.getDOM().getElementsByTagNameNS(SAMLConstants.SAML20_NS, "Assertion");
-        if (assertionList != null && assertionList.getLength() > 1) {
-            throw new SAMLSSOException(ErrorMessages.PROCESSING_SAML2_MULTIPLE_ASSERTION_ELEMENT_FOUND.getCode(),
-                    ErrorMessages.PROCESSING_SAML2_MULTIPLE_ASSERTION_ELEMENT_FOUND.getMessage());
+        boolean allowNestedAssertions = Boolean.parseBoolean(IdentityUtil.getProperty(
+                IdentityConstants.ServerConfig.SAML_ALLOW_NESTED_ASSERTIONS_IN_RESPONSE));
+        if (allowNestedAssertions && response instanceof Response) {
+            Response samlResponse = (Response) response;
+            if (samlResponse.getAssertions() != null && samlResponse.getAssertions().size() > 1) {
+                throw new SAMLSSOException(ErrorMessages.PROCESSING_SAML2_MULTIPLE_ASSERTION_ELEMENT_FOUND.getCode(),
+                        ErrorMessages.PROCESSING_SAML2_MULTIPLE_ASSERTION_ELEMENT_FOUND.getMessage());
+            }
+        } else {
+            // Checking for multiple Assertions. This is done to thwart possible XSW attacks.
+            NodeList assertionList = response.getDOM().getElementsByTagNameNS(SAMLConstants.SAML20_NS, "Assertion");
+            if (assertionList != null && assertionList.getLength() > 1) {
+                throw new SAMLSSOException(ErrorMessages.PROCESSING_SAML2_MULTIPLE_ASSERTION_ELEMENT_FOUND.getCode(),
+                        ErrorMessages.PROCESSING_SAML2_MULTIPLE_ASSERTION_ELEMENT_FOUND.getMessage());
+            }
         }
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -301,7 +301,7 @@
         <carbon.user.api.imp.pkg.version.range>[1.0.1, 2.0.0)</carbon.user.api.imp.pkg.version.range>
 
         <!--Carbon Identity Framework Version-->
-        <carbon.identity.framework.version>7.10.80</carbon.identity.framework.version>
+        <carbon.identity.framework.version>7.10.81</carbon.identity.framework.version>
         <carbon.identity.framework.imp.pkg.version.range>[5.15.0, 8.0.0)</carbon.identity.framework.imp.pkg.version.range>
 
         <identity.organization.management.core.version>1.0.85</identity.organization.management.core.version>

--- a/pom.xml
+++ b/pom.xml
@@ -301,7 +301,7 @@
         <carbon.user.api.imp.pkg.version.range>[1.0.1, 2.0.0)</carbon.user.api.imp.pkg.version.range>
 
         <!--Carbon Identity Framework Version-->
-        <carbon.identity.framework.version>7.10.70</carbon.identity.framework.version>
+        <carbon.identity.framework.version>7.10.80</carbon.identity.framework.version>
         <carbon.identity.framework.imp.pkg.version.range>[5.15.0, 8.0.0)</carbon.identity.framework.imp.pkg.version.range>
 
         <identity.organization.management.core.version>1.0.85</identity.organization.management.core.version>


### PR DESCRIPTION
## Important

To be merged after: https://github.com/wso2/carbon-identity-framework/pull/7842
Integration tests to be triggered for this PR after the above is merged.

## Purpose

Support snested assertions in SAML response based on the following config.
```
[saml.response]
allow_nested_assertions=true
```

## Related Issues

- https://github.com/wso2/product-is/issues/26849

## Related PRs

- https://github.com/wso2/carbon-identity-framework/pull/7842

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a configuration option to control how multiple assertions in SAML responses are validated, supporting either an assertion-count check or the existing DOM-based validation.

* **Chores**
  * Updated the identity framework dependency version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->