### PR TITLE
Add support for effective valid until time and cache duration calculation

### DIFF
--- a/components/org.wso2.carbon.identity.application.authenticator.samlsso/src/main/java/org/wso2/carbon/identity/application/authenticator/samlsso/cert/SAMLMetadataCertificateResolver.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.samlsso/src/main/java/org/wso2/carbon/identity/application/authenticator/samlsso/cert/SAMLMetadataCertificateResolver.java
@@ -97,8 +97,10 @@ public class SAMLMetadataCertificateResolver extends AbstractAPIClientManager {
      *
      * @param metadataUrl The URL of the SAML metadata endpoint.
      * @param entityId    The entity ID to match against the metadata's EntityDescriptor.
-     * @return A {@link RemoteCertificate} containing the resolved signing certificates together with the validUntil
-     *         and cacheDuration values from the metadata and the timestamp of this retrieval.
+     * @return A {@link RemoteCertificate} containing the resolved signing certificates together with the effective
+     *         validUntil and cacheDuration. These are derived by taking the most restrictive values —
+     *         earliest validUntil and shortest cacheDuration — across both the EntityDescriptor and each
+     *         IDPSSODescriptor found in the metadata.
      * @throws SAMLSSOException If the URL is invalid, the entity ID does not match, the metadata cannot be
      *                          fetched, the XML cannot be parsed, or a certificate value cannot be decoded.
      */
@@ -126,13 +128,15 @@ public class SAMLMetadataCertificateResolver extends AbstractAPIClientManager {
                 + metadataUrl);
         }
 
-        Instant validUntil = entityDescriptor.getValidUntil() != null
-                ? Instant.ofEpochMilli(entityDescriptor.getValidUntil().getMillis())
-                : null;
+        List<IDPSSODescriptor> idpDescriptors = entityDescriptor
+                .getRoleDescriptors(IDPSSODescriptor.DEFAULT_ELEMENT_NAME)
+                .stream()
+                .filter(IDPSSODescriptor.class::isInstance)
+                .map(IDPSSODescriptor.class::cast)
+                .collect(Collectors.toList());
 
-        Duration cacheDuration = entityDescriptor.getCacheDuration() != null
-                ? Duration.ofMillis(entityDescriptor.getCacheDuration())
-                : null;
+        Instant validUntil = resolveEffectiveValidUntil(entityDescriptor, idpDescriptors);
+        Duration cacheDuration = resolveEffectiveCacheDuration(entityDescriptor, idpDescriptors);
 
         return new RemoteCertificate.Builder(certificates)
                 .validUntil(validUntil)
@@ -270,6 +274,59 @@ public class SAMLMetadataCertificateResolver extends AbstractAPIClientManager {
         }
 
         return certificates;
+    }
+
+    /**
+     * Resolves the effective validUntil instant by taking the earliest non-null value from
+     * the EntityDescriptor and all IDPSSODescriptors.
+     *
+     * @param entityDescriptor The root metadata EntityDescriptor.
+     * @param idpDescriptors   IDPSSODescriptors contained in the EntityDescriptor.
+     * @return The earliest non-null validUntil as an {@link Instant}, or null if none is present.
+     */
+    private Instant resolveEffectiveValidUntil(EntityDescriptor entityDescriptor,
+            List<IDPSSODescriptor> idpDescriptors) {
+
+        Instant effectiveValidUntil = entityDescriptor.getValidUntil() != null
+                ? Instant.ofEpochMilli(entityDescriptor.getValidUntil().getMillis())
+                : null;
+
+        for (IDPSSODescriptor idpDescriptor : idpDescriptors) {
+            if (idpDescriptor.getValidUntil() != null) {
+                Instant idpValidUntil = Instant.ofEpochMilli(idpDescriptor.getValidUntil().getMillis());
+                if (effectiveValidUntil == null || idpValidUntil.isBefore(effectiveValidUntil)) {
+                    effectiveValidUntil = idpValidUntil;
+                }
+            }
+        }
+        return effectiveValidUntil;
+    }
+
+    /**
+     * Resolves the effective cacheDuration by taking the shortest non-null value from the
+     * EntityDescriptor and all IDPSSODescriptors.
+     *
+     * @param entityDescriptor The root metadata EntityDescriptor.
+     * @param idpDescriptors   IDPSSODescriptors contained in the EntityDescriptor.
+     * @return The shortest non-null cacheDuration as a {@link Duration}, or null if none is present.
+     */
+    private Duration resolveEffectiveCacheDuration(EntityDescriptor entityDescriptor,
+            List<IDPSSODescriptor> idpDescriptors) {
+
+        Duration effectiveCacheDuration = entityDescriptor.getCacheDuration() != null
+                ? Duration.ofMillis(entityDescriptor.getCacheDuration())
+                : null;
+
+        for (IDPSSODescriptor idpDescriptor : idpDescriptors) {
+            if (idpDescriptor.getCacheDuration() != null) {
+                Duration idpCacheDuration = Duration.ofMillis(idpDescriptor.getCacheDuration());
+                if (effectiveCacheDuration == null
+                        || idpCacheDuration.compareTo(effectiveCacheDuration) < 0) {
+                    effectiveCacheDuration = idpCacheDuration;
+                }
+            }
+        }
+        return effectiveCacheDuration;
     }
 
     /**

--- a/components/org.wso2.carbon.identity.application.authenticator.samlsso/src/test/java/org/wso2/carbon/identity/application/authenticator/samlsso/cert/SAMLMetadataCertificateResolverTest.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.samlsso/src/test/java/org/wso2/carbon/identity/application/authenticator/samlsso/cert/SAMLMetadataCertificateResolverTest.java
@@ -27,6 +27,7 @@ import org.opensaml.saml.saml2.metadata.KeyDescriptor;
 import org.opensaml.security.credential.UsageType;
 import org.opensaml.xmlsec.signature.KeyInfo;
 import org.opensaml.xmlsec.signature.X509Data;
+import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 import org.wso2.carbon.identity.application.authenticator.samlsso.exception.SAMLSSOException;
 import org.wso2.carbon.identity.application.authenticator.samlsso.model.RemoteCertificate;
@@ -56,6 +57,7 @@ import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertSame;
 import static org.testng.Assert.assertTrue;
 
@@ -78,6 +80,17 @@ public class SAMLMetadataCertificateResolverTest {
           + "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAIDAQABo1MwUTAdBgNVHQ4EFgQU"
           + "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA0wHwYDVR0jBBgwFoAUAAAAAAAAAAAAAAAA"
           + "AAAAAAAAAAAAAAAAA0wDQYJKoZIhvcNAQELBQADggEBAAAAAAAAAAAAAAAAAAAAAA==";
+
+    @BeforeClass
+    public void setUpClass() {
+
+        System.setProperty("carbon.home", getClass().getResource("/").getPath());
+        try (MockedStatic<SSOUtils> ssoUtilsMock = mockStatic(SSOUtils.class)) {
+            ssoUtilsMock.when(() -> SSOUtils.getAuthenticatorParamMap(anyString()))
+                    .thenReturn(Collections.emptyMap());
+            SAMLMetadataCertificateResolver.getInstance();
+        }
+    }
 
     @Test(description = "When the param key is absent from the config map, "
             + "getClientIntParam should return the supplied default value.")
@@ -1008,6 +1021,345 @@ public class SAMLMetadataCertificateResolverTest {
 
             assertEquals(result.getCacheDuration(), Duration.ofMillis(cacheDurationMillis),
                     "cacheDuration should be mapped correctly from the EntityDescriptor.");
+        }
+    }
+
+    @Test(description = "When both EntityDescriptor and all IDPSSODescriptors have null validUntil, "
+            + "resolveEffectiveValidUntil should return null.")
+    public void testResolveEffectiveValidUntil_BothNull_ReturnsNull() throws Exception {
+
+        EntityDescriptor mockDescriptor = mock(EntityDescriptor.class);
+        when(mockDescriptor.getValidUntil()).thenReturn(null);
+
+        IDPSSODescriptor mockIdpDescriptor = mock(IDPSSODescriptor.class);
+        when(mockIdpDescriptor.getValidUntil()).thenReturn(null);
+
+        Instant result = invokeResolveEffectiveValidUntil(mockDescriptor,
+                Collections.singletonList(mockIdpDescriptor));
+
+        assertNull(result, "Should return null when no validUntil is set anywhere.");
+    }
+
+    @Test(description = "When only the EntityDescriptor has a validUntil and IDPSSODescriptor has none, "
+            + "resolveEffectiveValidUntil should return the EntityDescriptor's value.")
+    public void testResolveEffectiveValidUntil_OnlyEntityDescriptor_ReturnsEntityDescriptorValue()
+            throws Exception {
+
+        long millis = 1000000000000L;
+        DateTime mockDateTime = mock(DateTime.class);
+        when(mockDateTime.getMillis()).thenReturn(millis);
+
+        EntityDescriptor mockDescriptor = mock(EntityDescriptor.class);
+        when(mockDescriptor.getValidUntil()).thenReturn(mockDateTime);
+
+        IDPSSODescriptor mockIdpDescriptor = mock(IDPSSODescriptor.class);
+        when(mockIdpDescriptor.getValidUntil()).thenReturn(null);
+
+        Instant result = invokeResolveEffectiveValidUntil(mockDescriptor,
+                Collections.singletonList(mockIdpDescriptor));
+
+        assertEquals(result, Instant.ofEpochMilli(millis),
+                "Should return the EntityDescriptor's validUntil when IDPSSODescriptor has none.");
+    }
+
+    @Test(description = "When only the IDPSSODescriptor has a validUntil and EntityDescriptor has none, "
+            + "resolveEffectiveValidUntil should return the IDPSSODescriptor's value.")
+    public void testResolveEffectiveValidUntil_OnlyIDPSSODescriptor_ReturnsIDPSSODescriptorValue()
+            throws Exception {
+
+        long idpMillis = 2000000000000L;
+        DateTime mockIdpDateTime = mock(DateTime.class);
+        when(mockIdpDateTime.getMillis()).thenReturn(idpMillis);
+
+        EntityDescriptor mockDescriptor = mock(EntityDescriptor.class);
+        when(mockDescriptor.getValidUntil()).thenReturn(null);
+
+        IDPSSODescriptor mockIdpDescriptor = mock(IDPSSODescriptor.class);
+        when(mockIdpDescriptor.getValidUntil()).thenReturn(mockIdpDateTime);
+
+        Instant result = invokeResolveEffectiveValidUntil(mockDescriptor,
+                Collections.singletonList(mockIdpDescriptor));
+
+        assertEquals(result, Instant.ofEpochMilli(idpMillis),
+                "Should return the IDPSSODescriptor's validUntil when EntityDescriptor has none.");
+    }
+
+    @Test(description = "When the IDPSSODescriptor has an earlier validUntil than the EntityDescriptor, "
+            + "resolveEffectiveValidUntil should return the IDPSSODescriptor's (earlier) value.")
+    public void testResolveEffectiveValidUntil_IDPSSODescriptorEarlier_ReturnsIDPSSODescriptorValue()
+            throws Exception {
+
+        long entityMillis = 2000000000000L; // later.
+        long idpMillis    = 1000000000000L; // earlier.
+
+        DateTime mockEntityDateTime = mock(DateTime.class);
+        when(mockEntityDateTime.getMillis()).thenReturn(entityMillis);
+
+        DateTime mockIdpDateTime = mock(DateTime.class);
+        when(mockIdpDateTime.getMillis()).thenReturn(idpMillis);
+
+        EntityDescriptor mockDescriptor = mock(EntityDescriptor.class);
+        when(mockDescriptor.getValidUntil()).thenReturn(mockEntityDateTime);
+
+        IDPSSODescriptor mockIdpDescriptor = mock(IDPSSODescriptor.class);
+        when(mockIdpDescriptor.getValidUntil()).thenReturn(mockIdpDateTime);
+
+        Instant result = invokeResolveEffectiveValidUntil(mockDescriptor,
+                Collections.singletonList(mockIdpDescriptor));
+
+        assertEquals(result, Instant.ofEpochMilli(idpMillis),
+                "IDPSSODescriptor's earlier validUntil should win over EntityDescriptor's later value.");
+    }
+
+    @Test(description = "When the EntityDescriptor has an earlier validUntil than the IDPSSODescriptor, "
+            + "resolveEffectiveValidUntil should return the EntityDescriptor's (earlier) value.")
+    public void testResolveEffectiveValidUntil_EntityDescriptorEarlier_ReturnsEntityDescriptorValue()
+            throws Exception {
+
+        long entityMillis = 1000000000000L; // earlier.
+        long idpMillis    = 2000000000000L; // later.
+
+        DateTime mockEntityDateTime = mock(DateTime.class);
+        when(mockEntityDateTime.getMillis()).thenReturn(entityMillis);
+
+        DateTime mockIdpDateTime = mock(DateTime.class);
+        when(mockIdpDateTime.getMillis()).thenReturn(idpMillis);
+
+        EntityDescriptor mockDescriptor = mock(EntityDescriptor.class);
+        when(mockDescriptor.getValidUntil()).thenReturn(mockEntityDateTime);
+
+        IDPSSODescriptor mockIdpDescriptor = mock(IDPSSODescriptor.class);
+        when(mockIdpDescriptor.getValidUntil()).thenReturn(mockIdpDateTime);
+
+        Instant result = invokeResolveEffectiveValidUntil(mockDescriptor,
+                Collections.singletonList(mockIdpDescriptor));
+
+        assertEquals(result, Instant.ofEpochMilli(entityMillis),
+                "EntityDescriptor's earlier validUntil should win over IDPSSODescriptor's later value.");
+    }
+
+    @Test(description = "When multiple IDPSSODescriptors are present, "
+            + "resolveEffectiveValidUntil should return the earliest value across all of them.")
+    public void testResolveEffectiveValidUntil_MultipleIDPSSODescriptors_ReturnsEarliest()
+            throws Exception {
+
+        long entityMillis = 3000000000000L;
+        long idp1Millis   = 1000000000000L; // earliest.
+        long idp2Millis   = 2000000000000L;
+
+        DateTime mockEntityDateTime = mock(DateTime.class);
+        when(mockEntityDateTime.getMillis()).thenReturn(entityMillis);
+
+        DateTime mockIdp1DateTime = mock(DateTime.class);
+        when(mockIdp1DateTime.getMillis()).thenReturn(idp1Millis);
+
+        DateTime mockIdp2DateTime = mock(DateTime.class);
+        when(mockIdp2DateTime.getMillis()).thenReturn(idp2Millis);
+
+        EntityDescriptor mockDescriptor = mock(EntityDescriptor.class);
+        when(mockDescriptor.getValidUntil()).thenReturn(mockEntityDateTime);
+
+        IDPSSODescriptor mockIdp1 = mock(IDPSSODescriptor.class);
+        when(mockIdp1.getValidUntil()).thenReturn(mockIdp1DateTime);
+
+        IDPSSODescriptor mockIdp2 = mock(IDPSSODescriptor.class);
+        when(mockIdp2.getValidUntil()).thenReturn(mockIdp2DateTime);
+
+        Instant result = invokeResolveEffectiveValidUntil(mockDescriptor,
+                Arrays.asList(mockIdp1, mockIdp2));
+
+        assertEquals(result, Instant.ofEpochMilli(idp1Millis),
+                "Should return the globally earliest validUntil across all descriptors.");
+    }
+
+    /**
+     * Invokes the private resolveEffectiveValidUntil method via reflection.
+     */
+    private Instant invokeResolveEffectiveValidUntil(EntityDescriptor entityDescriptor,
+            List<IDPSSODescriptor> idpDescriptors) throws Exception {
+
+        Method method = SAMLMetadataCertificateResolver.class
+                .getDeclaredMethod("resolveEffectiveValidUntil", EntityDescriptor.class, List.class);
+        method.setAccessible(true);
+        return (Instant) method.invoke(SAMLMetadataCertificateResolver.getInstance(),
+                entityDescriptor, idpDescriptors);
+    }
+
+    @Test(description = "When both EntityDescriptor and all IDPSSODescriptors have null cacheDuration, "
+            + "resolveEffectiveCacheDuration should return null.")
+    public void testResolveEffectiveCacheDuration_BothNull_ReturnsNull() throws Exception {
+
+        EntityDescriptor mockDescriptor = mock(EntityDescriptor.class);
+        when(mockDescriptor.getCacheDuration()).thenReturn(null);
+
+        IDPSSODescriptor mockIdpDescriptor = mock(IDPSSODescriptor.class);
+        when(mockIdpDescriptor.getCacheDuration()).thenReturn(null);
+
+        Duration result = invokeResolveEffectiveCacheDuration(mockDescriptor,
+                Collections.singletonList(mockIdpDescriptor));
+
+        assertNull(result, "Should return null when no cacheDuration is set anywhere.");
+    }
+
+    @Test(description = "When only the EntityDescriptor has a cacheDuration and IDPSSODescriptor has none, "
+            + "resolveEffectiveCacheDuration should return the EntityDescriptor's value.")
+    public void testResolveEffectiveCacheDuration_OnlyEntityDescriptor_ReturnsEntityDescriptorValue()
+            throws Exception {
+
+        long entityDuration = 7200000L;
+
+        EntityDescriptor mockDescriptor = mock(EntityDescriptor.class);
+        when(mockDescriptor.getCacheDuration()).thenReturn(entityDuration);
+
+        IDPSSODescriptor mockIdpDescriptor = mock(IDPSSODescriptor.class);
+        when(mockIdpDescriptor.getCacheDuration()).thenReturn(null);
+
+        Duration result = invokeResolveEffectiveCacheDuration(mockDescriptor,
+                Collections.singletonList(mockIdpDescriptor));
+
+        assertEquals(result, Duration.ofMillis(entityDuration),
+                "Should return the EntityDescriptor's cacheDuration when IDPSSODescriptor has none.");
+    }
+
+    @Test(description = "When only the IDPSSODescriptor has a cacheDuration and EntityDescriptor has none, "
+            + "resolveEffectiveCacheDuration should return the IDPSSODescriptor's value.")
+    public void testResolveEffectiveCacheDuration_OnlyIDPSSODescriptor_ReturnsIDPSSODescriptorValue()
+            throws Exception {
+
+        long idpDuration = 3600000L;
+
+        EntityDescriptor mockDescriptor = mock(EntityDescriptor.class);
+        when(mockDescriptor.getCacheDuration()).thenReturn(null);
+
+        IDPSSODescriptor mockIdpDescriptor = mock(IDPSSODescriptor.class);
+        when(mockIdpDescriptor.getCacheDuration()).thenReturn(idpDuration);
+
+        Duration result = invokeResolveEffectiveCacheDuration(mockDescriptor,
+                Collections.singletonList(mockIdpDescriptor));
+
+        assertEquals(result, Duration.ofMillis(idpDuration),
+                "Should return the IDPSSODescriptor's cacheDuration when EntityDescriptor has none.");
+    }
+
+    @Test(description = "When the IDPSSODescriptor has a shorter cacheDuration than the EntityDescriptor, "
+            + "resolveEffectiveCacheDuration should return the IDPSSODescriptor's (shorter) value.")
+    public void testResolveEffectiveCacheDuration_IDPSSODescriptorShorter_ReturnsIDPSSODescriptorValue()
+            throws Exception {
+
+        long entityDuration = 7200000L; // longer.
+        long idpDuration    = 1800000L; // shorter.
+
+        EntityDescriptor mockDescriptor = mock(EntityDescriptor.class);
+        when(mockDescriptor.getCacheDuration()).thenReturn(entityDuration);
+
+        IDPSSODescriptor mockIdpDescriptor = mock(IDPSSODescriptor.class);
+        when(mockIdpDescriptor.getCacheDuration()).thenReturn(idpDuration);
+
+        Duration result = invokeResolveEffectiveCacheDuration(mockDescriptor,
+                Collections.singletonList(mockIdpDescriptor));
+
+        assertEquals(result, Duration.ofMillis(idpDuration),
+                "IDPSSODescriptor's shorter cacheDuration should win over EntityDescriptor's longer value.");
+    }
+
+    @Test(description = "When the EntityDescriptor has a shorter cacheDuration than the IDPSSODescriptor, "
+            + "resolveEffectiveCacheDuration should return the EntityDescriptor's (shorter) value.")
+    public void testResolveEffectiveCacheDuration_EntityDescriptorShorter_ReturnsEntityDescriptorValue()
+            throws Exception {
+
+        long entityDuration = 1800000L; // shorter.
+        long idpDuration    = 7200000L; // longer.
+
+        EntityDescriptor mockDescriptor = mock(EntityDescriptor.class);
+        when(mockDescriptor.getCacheDuration()).thenReturn(entityDuration);
+
+        IDPSSODescriptor mockIdpDescriptor = mock(IDPSSODescriptor.class);
+        when(mockIdpDescriptor.getCacheDuration()).thenReturn(idpDuration);
+
+        Duration result = invokeResolveEffectiveCacheDuration(mockDescriptor,
+                Collections.singletonList(mockIdpDescriptor));
+
+        assertEquals(result, Duration.ofMillis(entityDuration),
+                "EntityDescriptor's shorter cacheDuration should win over IDPSSODescriptor's longer value.");
+    }
+
+    @Test(description = "When multiple IDPSSODescriptors are present, "
+            + "resolveEffectiveCacheDuration should return the shortest value across all of them.")
+    public void testResolveEffectiveCacheDuration_MultipleIDPSSODescriptors_ReturnsShortest()
+            throws Exception {
+
+        long entityDuration = 7200000L;
+        long idp1Duration   =  900000L; // shortest.
+        long idp2Duration   = 3600000L;
+
+        EntityDescriptor mockDescriptor = mock(EntityDescriptor.class);
+        when(mockDescriptor.getCacheDuration()).thenReturn(entityDuration);
+
+        IDPSSODescriptor mockIdp1 = mock(IDPSSODescriptor.class);
+        when(mockIdp1.getCacheDuration()).thenReturn(idp1Duration);
+
+        IDPSSODescriptor mockIdp2 = mock(IDPSSODescriptor.class);
+        when(mockIdp2.getCacheDuration()).thenReturn(idp2Duration);
+
+        Duration result = invokeResolveEffectiveCacheDuration(mockDescriptor,
+                Arrays.asList(mockIdp1, mockIdp2));
+
+        assertEquals(result, Duration.ofMillis(idp1Duration),
+                "Should return the globally shortest cacheDuration across all descriptors.");
+    }
+
+    /**
+     * Invokes the private resolveEffectiveCacheDuration method via reflection.
+     */
+    private Duration invokeResolveEffectiveCacheDuration(EntityDescriptor entityDescriptor,
+            List<IDPSSODescriptor> idpDescriptors) throws Exception {
+
+        Method method = SAMLMetadataCertificateResolver.class
+                .getDeclaredMethod("resolveEffectiveCacheDuration", EntityDescriptor.class, List.class);
+        method.setAccessible(true);
+        return (Duration) method.invoke(SAMLMetadataCertificateResolver.getInstance(),
+                entityDescriptor, idpDescriptors);
+    }
+
+    @Test(description = "When the IDPSSODescriptor has an earlier validUntil than the EntityDescriptor, "
+            + "getSigningCertificatesFromMetadata should use the IDPSSODescriptor's value.")
+    public void testGetSigningCertificatesFromMetadata_IDPSSODescriptorEarlierValidUntil_UsesIDPSSODescriptorValue()
+            throws Exception {
+
+        long entityMillis = 2000000000000L; // later.
+        long idpMillis    = 1000000000000L; // earlier.
+
+        DateTime mockEntityDateTime = mock(DateTime.class);
+        when(mockEntityDateTime.getMillis()).thenReturn(entityMillis);
+
+        DateTime mockIdpDateTime = mock(DateTime.class);
+        when(mockIdpDateTime.getMillis()).thenReturn(idpMillis);
+
+        IDPSSODescriptor mockIdpDescriptor = mock(IDPSSODescriptor.class);
+        when(mockIdpDescriptor.getValidUntil()).thenReturn(mockIdpDateTime);
+        when(mockIdpDescriptor.getCacheDuration()).thenReturn(null);
+        when(mockIdpDescriptor.getKeyDescriptors()).thenReturn(Collections.emptyList());
+
+        EntityDescriptor mockDescriptor = mock(EntityDescriptor.class);
+        when(mockDescriptor.getEntityID()).thenReturn(ENTITY_ID);
+        when(mockDescriptor.getValidUntil()).thenReturn(mockEntityDateTime);
+        when(mockDescriptor.getCacheDuration()).thenReturn(null);
+        when(mockDescriptor.getRoleDescriptors(any()))
+                .thenReturn(Collections.singletonList(mockIdpDescriptor));
+
+        SAMLMetadataCertificateResolver spy = spy(SAMLMetadataCertificateResolver.getInstance());
+        doReturn(new APIResponse(200, RAW_METADATA)).when(spy).callAPI(any(), any());
+
+        try (MockedStatic<SSOUtils> ssoUtilsMock = mockStatic(SSOUtils.class)) {
+            ssoUtilsMock.when(() -> SSOUtils.getAuthenticatorParamMap(anyString()))
+                    .thenReturn(Collections.emptyMap());
+            ssoUtilsMock.when(() -> SSOUtils.unmarshall(RAW_METADATA))
+                    .thenReturn(mockDescriptor);
+
+            RemoteCertificate result = spy.getSigningCertificatesFromMetadata(METADATA_URL, ENTITY_ID);
+
+            assertEquals(result.getValidUntil(), Instant.ofEpochMilli(idpMillis),
+                    "IDPSSODescriptor's earlier validUntil should be used.");
         }
     }
 }


### PR DESCRIPTION
### Purpose
This pull request enhances how SAML metadata validity and cache durations are determined in the `SAMLMetadataCertificateResolver`, and significantly expands the test coverage to ensure correctness. The main improvement is that the code now calculates the most restrictive (earliest/shortest) `validUntil` and `cacheDuration` values by considering both the root `EntityDescriptor` and all contained `IDPSSODescriptor` elements, rather than just the root. This change is thoroughly tested with new unit tests covering all edge cases.

### SAML Metadata Validity and Cache Duration Calculation

* The logic for determining the effective `validUntil` and `cacheDuration` for a SAML metadata endpoint has been refactored: the code now computes the earliest `validUntil` and the shortest `cacheDuration` from both the `EntityDescriptor` and all `IDPSSODescriptor` elements, ensuring the most restrictive values are used. [[1]](diffhunk://#diff-9621828024e9f1b68901918a533261fc68170404d853f369fa6b0fab5273ebd3L100-R103) [[2]](diffhunk://#diff-9621828024e9f1b68901918a533261fc68170404d853f369fa6b0fab5273ebd3L129-R139) [[3]](diffhunk://#diff-9621828024e9f1b68901918a533261fc68170404d853f369fa6b0fab5273ebd3R279-R331)

### Unit Test Improvements

* Added comprehensive unit tests for the new logic, verifying all combinations and edge cases for `validUntil` and `cacheDuration` selection, including scenarios with nulls, only one source present, and multiple descriptors. This ensures the new behavior is robust and correct.
* Added setup and utility methods in the test class to support the new tests, including reflection helpers to access private methods. [[1]](diffhunk://#diff-677687d929866db8c822f7263aff131496a2f2ab6d72efaf64795cbf82c89434R30) [[2]](diffhunk://#diff-677687d929866db8c822f7263aff131496a2f2ab6d72efaf64795cbf82c89434R60) [[3]](diffhunk://#diff-677687d929866db8c822f7263aff131496a2f2ab6d72efaf64795cbf82c89434R84-R94)

These changes make the SAML metadata certificate resolution more standards-compliant and reliable, and the expanded tests will help catch regressions in the future.

### Related Issue
- https://github.com/wso2/product-is/issues/26845

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced SAML metadata processing to correctly handle validity periods and cache durations across multiple configurations, improving authentication reliability.

* **Tests**
  * Expanded test suite with comprehensive coverage for validity resolution, cache computation, certificate extraction, and edge case handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->