### PR TITLE
Refactor cache operations to use read-safe methods for concurrent environments

### DIFF
--- a/components/org.wso2.carbon.identity.application.authenticator.samlsso/src/main/java/org/wso2/carbon/identity/application/authenticator/samlsso/cert/RemoteCertificateProcessor.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.samlsso/src/main/java/org/wso2/carbon/identity/application/authenticator/samlsso/cert/RemoteCertificateProcessor.java
@@ -329,7 +329,7 @@ public class RemoteCertificateProcessor {
                     .getSigningCertificatesFromMetadata(metadataUrl, entityId);
 
             cache.clearCacheEntry(cacheKey, tenantDomain);
-            cache.addToCache(cacheKey, new SAMLCertCacheEntry(remoteCertificate), tenantDomain);
+            cache.addToCacheOnRead(cacheKey, new SAMLCertCacheEntry(remoteCertificate), tenantDomain);
 
             if (LOG.isDebugEnabled()) {
                 LOG.debug("Fetched and cached " + remoteCertificate.getCertificates().size()

--- a/components/org.wso2.carbon.identity.application.authenticator.samlsso/src/test/java/org/wso2/carbon/identity/application/authenticator/samlsso/cert/RemoteCertificateProcessorTest.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.samlsso/src/test/java/org/wso2/carbon/identity/application/authenticator/samlsso/cert/RemoteCertificateProcessorTest.java
@@ -175,7 +175,7 @@ public class RemoteCertificateProcessorTest {
                     "Should return the certificates fetched from the metadata resolver on a cache miss.");
             verify(mockResolver).getSigningCertificatesFromMetadata(METADATA_URL, ENTITY_ID);
             verify(mockCache).clearCacheEntry(any(SAMLCertCacheKey.class), eq(TENANT_DOMAIN));
-            verify(mockCache).addToCache(any(SAMLCertCacheKey.class), any(SAMLCertCacheEntry.class),
+            verify(mockCache).addToCacheOnRead(any(SAMLCertCacheKey.class), any(SAMLCertCacheEntry.class),
                     eq(TENANT_DOMAIN));
         }
     }
@@ -214,7 +214,7 @@ public class RemoteCertificateProcessorTest {
                     "Should return fresh certificates after the stale cache entry is replaced.");
             verify(mockResolver).getSigningCertificatesFromMetadata(METADATA_URL, ENTITY_ID);
             verify(mockCache).clearCacheEntry(any(SAMLCertCacheKey.class), eq(TENANT_DOMAIN));
-            verify(mockCache).addToCache(any(SAMLCertCacheKey.class), any(SAMLCertCacheEntry.class),
+            verify(mockCache).addToCacheOnRead(any(SAMLCertCacheKey.class), any(SAMLCertCacheEntry.class),
                     eq(TENANT_DOMAIN));
         }
     }

--- a/pom.xml
+++ b/pom.xml
@@ -295,13 +295,13 @@
         <identity.outbound.auth.samlsso.imp.pkg.version.range>[1.0.0, 2.0.0)</identity.outbound.auth.samlsso.imp.pkg.version.range>
 
         <!--Carbon Kernel Version-->
-        <carbon.kernel.version>4.12.15</carbon.kernel.version>
+        <carbon.kernel.version>4.10.22</carbon.kernel.version>
         <carbon.kernel.feature.version>4.10.22</carbon.kernel.feature.version>
         <carbon.kernel.imp.pkg.version.range>[4.4.0, 5.0.0)</carbon.kernel.imp.pkg.version.range>
         <carbon.user.api.imp.pkg.version.range>[1.0.1, 2.0.0)</carbon.user.api.imp.pkg.version.range>
 
         <!--Carbon Identity Framework Version-->
-        <carbon.identity.framework.version>7.10.106</carbon.identity.framework.version>
+        <carbon.identity.framework.version>7.10.119</carbon.identity.framework.version>
         <carbon.identity.framework.imp.pkg.version.range>[5.15.0, 8.0.0)</carbon.identity.framework.imp.pkg.version.range>
 
         <identity.organization.management.core.version>1.0.85</identity.organization.management.core.version>

--- a/pom.xml
+++ b/pom.xml
@@ -295,13 +295,13 @@
         <identity.outbound.auth.samlsso.imp.pkg.version.range>[1.0.0, 2.0.0)</identity.outbound.auth.samlsso.imp.pkg.version.range>
 
         <!--Carbon Kernel Version-->
-        <carbon.kernel.version>4.10.22</carbon.kernel.version>
+        <carbon.kernel.version>4.12.15</carbon.kernel.version>
         <carbon.kernel.feature.version>4.10.22</carbon.kernel.feature.version>
         <carbon.kernel.imp.pkg.version.range>[4.4.0, 5.0.0)</carbon.kernel.imp.pkg.version.range>
         <carbon.user.api.imp.pkg.version.range>[1.0.1, 2.0.0)</carbon.user.api.imp.pkg.version.range>
 
         <!--Carbon Identity Framework Version-->
-        <carbon.identity.framework.version>7.10.81</carbon.identity.framework.version>
+        <carbon.identity.framework.version>7.10.106</carbon.identity.framework.version>
         <carbon.identity.framework.imp.pkg.version.range>[5.15.0, 8.0.0)</carbon.identity.framework.imp.pkg.version.range>
 
         <identity.organization.management.core.version>1.0.85</identity.organization.management.core.version>


### PR DESCRIPTION
Related issue: https://github.com/wso2/product-is/issues/26225

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated Carbon Identity Framework dependency from 7.10.81 to 7.10.119.

* **Bug Fixes / Improvements**
  * Adjusted remote certificate caching to defer cache population until read time for more robust handling.

* **Tests**
  * Updated unit tests to align with the revised caching behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->