### PR TITLE
Accept SAML LogoutRequest with missing/blank Issuer Format

### DIFF
--- a/components/org.wso2.carbon.identity.application.authenticator.samlsso/src/main/java/org/wso2/carbon/identity/application/authenticator/samlsso/logout/validators/LogoutRequestValidator.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.samlsso/src/main/java/org/wso2/carbon/identity/application/authenticator/samlsso/logout/validators/LogoutRequestValidator.java
@@ -123,7 +123,7 @@ public class LogoutRequestValidator {
             throw new SAMLLogoutException(notification, errorResponse, logoutRequest.getDestination(),
                     samlMessageContext.getRelayState());
         }
-        if (StringUtils.isBlank(logoutRequest.getIssuer().getFormat()) ||
+        if (StringUtils.isNotBlank(logoutRequest.getIssuer().getFormat()) &&
                 !(ISSUER_FORMAT.equals(logoutRequest.getIssuer().getFormat()))) {
             String notification = "Invalid Issuer Format in the logout request";
             if (log.isDebugEnabled()) {

--- a/components/org.wso2.carbon.identity.application.authenticator.samlsso/src/test/java/org/wso2/carbon/identity/application/authenticator/samlsso/logout/validators/LogoutRequestValidatorTest.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.samlsso/src/test/java/org/wso2/carbon/identity/application/authenticator/samlsso/logout/validators/LogoutRequestValidatorTest.java
@@ -35,6 +35,7 @@ import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 import org.wso2.carbon.identity.application.authentication.framework.inbound.IdentityRequest;
 import org.wso2.carbon.identity.application.authenticator.samlsso.logout.context.SAMLMessageContext;
+import org.wso2.carbon.identity.application.authenticator.samlsso.logout.exception.SAMLLogoutException;
 
 import static org.opensaml.saml.common.SAMLVersion.VERSION_20;
 import static org.testng.Assert.assertEquals;
@@ -108,7 +109,54 @@ public class LogoutRequestValidatorTest {
                         mockedEncId,
                         "false",
                         true
+                },
+                // Issuer Format is optional per SAML 2.0 Core (defaults to entity) - a null Format must be accepted.
+                {
+                        VERSION_20,
+                        SP_ENTITY_ID,
+                        null,
+                        mockedNameId,
+                        mockedBaseId,
+                        mockedEncId,
+                        "false",
+                        true
+                },
+                // A blank Issuer Format must be accepted as well.
+                {
+                        VERSION_20,
+                        SP_ENTITY_ID,
+                        "",
+                        mockedNameId,
+                        mockedBaseId,
+                        mockedEncId,
+                        "false",
+                        true
                 }
         };
+    }
+
+    /**
+     * A Format that is present but is not the entity format must still be rejected.
+     */
+    @Test(expectedExceptions = SAMLLogoutException.class)
+    public void testIsValidWithInvalidIssuerFormat() throws SAMLLogoutException {
+
+        SAMLMessageContext mockedContext = new SAMLMessageContext(mockedIdentityRequest, new HashMap());
+        mockedContext.setValidStatus(true);
+
+        LogoutRequest logReq = new LogoutRequestBuilder().buildObject();
+        logReq.setVersion(VERSION_20);
+
+        Issuer issuer = new IssuerBuilder().buildObject();
+        issuer.setValue(SP_ENTITY_ID);
+        issuer.setFormat("urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified");
+        logReq.setIssuer(issuer);
+        logReq.setNameID(mockedNameId);
+
+        Map<String, String> mockedFedIdPConfigs = new HashMap<>();
+        mockedFedIdPConfigs.put(IS_LOGOUT_REQ_SIGNED, "false");
+        mockedContext.setFedIdPConfigs(mockedFedIdPConfigs);
+
+        new LogoutRequestValidator(mockedContext).isValidate(logReq);
     }
 }


### PR DESCRIPTION
## Problem
IdP-initiated SAML single logout (`POST /identity/saml/slo`) fails when the inbound `<LogoutRequest>` has an `<Issuer>` **without** a `Format` attribute.

`LogoutRequestValidator.isIssuerValid()` used:
```java
if (StringUtils.isBlank(getFormat()) || !ISSUER_FORMAT.equals(getFormat()))
```
so a missing/blank `Format` was rejected. Per **SAML 2.0 Core §2.2.1** the `Format` on `<Issuer>` is **OPTIONAL** and, when omitted, means the `entity` format. IdPs that legitimately omit it cannot single-logout.

## Fix
```java
if (StringUtils.isNotBlank(getFormat()) && !ISSUER_FORMAT.equals(getFormat()))
```
Missing/blank Format is accepted (entity default); a present-but-wrong Format is still rejected.

| Format on `<Issuer>` | Before | After |
|---|---|---|
| absent / blank | ❌ rejected | ✅ accepted (entity default) |
| `...:nameid-format:entity` | ✅ | ✅ |
| present, non-entity | ❌ | ❌ (unchanged) |

## Tests
- Added data-provider rows: `Format=null` → valid, `Format=""` → valid.
- Added `testIsValidWithInvalidIssuerFormat` — present-but-wrong Format still throws `SAMLLogoutException`.
- `mvn clean install` green on the module.

Fixes: https://github.com/wso2/product-is/issues/27861

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed SAML logout request validation to properly handle issuer format values, now accepting requests with blank or null formats while correctly rejecting requests with invalid format values.

* **Tests**
  * Added test coverage for issuer format validation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->